### PR TITLE
Prepare kbase onto shared lib 260716

### DIFF
--- a/Data/PlantSEED_v3/PlantSEED_Complexes.json
+++ b/Data/PlantSEED_v3/PlantSEED_Complexes.json
@@ -4453,29 +4453,6 @@
         }
     },
     {
-        "kbase_id": "PS_complex_5831c7",
-        "enzyme": "Desulfoglucosinolate sulfotransferase",
-        "roles": [
-            "Aliphatic desulfoglucosinolate sulfotransferase (EC 2.8.2.38)"
-        ],
-        "compartments_reactions": {
-            "c": {
-                "reactions": [
-                    "rxn27056",
-                    "rxn14133",
-                    "rxn02300",
-                    "rxn14362",
-                    "rxn27057",
-                    "rxn11704",
-                    "rxn27059",
-                    "rxn27058"
-                ],
-                "reagents": "c",
-                "exclude": false
-            }
-        }
-    },
-    {
         "kbase_id": "PS_complex_efcd53",
         "enzyme": "Dethiobiotin synthetase",
         "roles": [
@@ -5502,22 +5479,6 @@
         }
     },
     {
-        "kbase_id": "PS_complex_ed48c3",
-        "enzyme": "Flavin-containing glucosinolate S-oxygenase",
-        "roles": [
-            "Aliphatic glucosinolate S-oxygenase (EC 1.14.13.237)"
-        ],
-        "compartments_reactions": {
-            "c": {
-                "reactions": [
-                    "rxn41751"
-                ],
-                "reagents": "c",
-                "exclude": false
-            }
-        }
-    },
-    {
         "kbase_id": "PS_complex_2f6edb",
         "enzyme": "Flavonoid 3'-monooxygenase",
         "roles": [
@@ -5989,29 +5950,6 @@
             "c": {
                 "reactions": [
                     "rxn01455"
-                ],
-                "reagents": "c",
-                "exclude": false
-            }
-        }
-    },
-    {
-        "kbase_id": "PS_complex_f80bf6",
-        "enzyme": "Gamma-glutamyl peptidase in glucosinolates biosynthesis",
-        "roles": [
-            "Glucosinolate gamma-glutamyl hydrolase (EC 3.4.19.16)"
-        ],
-        "compartments_reactions": {
-            "c": {
-                "reactions": [
-                    "rxn21822",
-                    "rxn21819",
-                    "rxn21818",
-                    "rxn21821",
-                    "rxn21817",
-                    "rxn21824",
-                    "rxn21820",
-                    "rxn21823"
                 ],
                 "reagents": "c",
                 "exclude": false
@@ -10027,27 +9965,6 @@
         }
     },
     {
-        "kbase_id": "PS_complex_82bdcd",
-        "enzyme": "Oxime metabolizining monooxygenase in aliphatic glucosinolates biosynthesis",
-        "roles": [
-            "(Methylsulfanyl)alkanaldoxime N-monooxygenase (EC 1.14.14.43)"
-        ],
-        "compartments_reactions": {
-            "c": {
-                "reactions": [
-                    "rxn21796",
-                    "rxn21804",
-                    "rxn21802",
-                    "rxn21798",
-                    "rxn21806",
-                    "rxn21800"
-                ],
-                "reagents": "c",
-                "exclude": false
-            }
-        }
-    },
-    {
         "kbase_id": "PS_complex_cfcb38",
         "enzyme": "Oxygen transport",
         "roles": [
@@ -12259,24 +12176,6 @@
                     "rxn00126"
                 ],
                 "reagents": "n",
-                "exclude": false
-            }
-        }
-    },
-    {
-        "kbase_id": "PS_complex_1374b1",
-        "enzyme": "S-alkyl-thiohydroximate lyase",
-        "roles": [
-            "Alkylthiohydroximate C-S lyase (EC 4.4.1.13)"
-        ],
-        "compartments_reactions": {
-            "c": {
-                "reactions": [
-                    "rxn24582",
-                    "rxn14068",
-                    "rxn12019"
-                ],
-                "reagents": "c",
                 "exclude": false
             }
         }
@@ -15590,6 +15489,115 @@
             "cpd00015": "0",
             "cpd00982": "0",
             "cpd00067": "3"
+        }
+    },
+    {
+        "kbase_id": "PS_complex_2a49f5",
+        "enzyme": "(Methylsulfanyl)alkanaldoxime N-monooxygenase",
+        "roles": [
+            "(Methylsulfanyl)alkanaldoxime N-monooxygenase (EC 1.14.14.43)"
+        ],
+        "compartments_reactions": {
+            "c": {
+                "reactions": [
+                    "rxn21796",
+                    "rxn21798",
+                    "rxn21800",
+                    "rxn21802",
+                    "rxn21804",
+                    "rxn21806"
+                ],
+                "reagents": "c",
+                "exclude": false
+            }
+        }
+    },
+    {
+        "kbase_id": "PS_complex_69ea3e",
+        "enzyme": "Aliphatic desulfoglucosinolate sulfotransferase",
+        "roles": [
+            "Aliphatic desulfoglucosinolate sulfotransferase (EC 2.8.2.38)"
+        ],
+        "compartments_reactions": {
+            "c": {
+                "reactions": [
+                    "rxn02300",
+                    "rxn11704",
+                    "rxn14133",
+                    "rxn14362",
+                    "rxn27056",
+                    "rxn27057",
+                    "rxn27058",
+                    "rxn27059"
+                ],
+                "reagents": "c",
+                "exclude": false
+            }
+        }
+    },
+    {
+        "kbase_id": "PS_complex_12c851",
+        "enzyme": "Aliphatic glucosinolate S-oxygenase",
+        "roles": [
+            "Aliphatic glucosinolate S-oxygenase (EC 1.14.13.237)"
+        ],
+        "compartments_reactions": {
+            "c": {
+                "reactions": [
+                    "rxn41751"
+                ],
+                "reagents": "c",
+                "exclude": false
+            }
+        }
+    },
+    {
+        "kbase_id": "PS_complex_3ee0b3",
+        "enzyme": "Alkylthiohydroximate C-S lyase",
+        "roles": [
+            "Alkylthiohydroximate C-S lyase (EC 4.4.1.13)"
+        ],
+        "compartments_reactions": {
+            "c": {
+                "reactions": [
+                    "rxn12019",
+                    "rxn14068",
+                    "rxn24582"
+                ],
+                "reagents": "c",
+                "exclude": false
+            }
+        }
+    },
+    {
+        "kbase_id": "PS_complex_c1a4a3",
+        "enzyme": "Aromatic desulfoglucosinolate sulfotransferase",
+        "roles": [
+            "Aromatic desulfoglucosinolate sulfotransferase (EC 2.8.2.24)"
+        ],
+        "compartments_reactions": {}
+    },
+    {
+        "kbase_id": "PS_complex_660e96",
+        "enzyme": "Glucosinolate gamma-glutamyl hydrolase",
+        "roles": [
+            "Glucosinolate gamma-glutamyl hydrolase (EC 3.4.19.16)"
+        ],
+        "compartments_reactions": {
+            "c": {
+                "reactions": [
+                    "rxn21817",
+                    "rxn21818",
+                    "rxn21819",
+                    "rxn21820",
+                    "rxn21821",
+                    "rxn21822",
+                    "rxn21823",
+                    "rxn21824"
+                ],
+                "reagents": "c",
+                "exclude": false
+            }
         }
     }
 ]

--- a/Scripts/PlantSEED_v3/Curation/PlantSEED_Complexes_Schema.yaml
+++ b/Scripts/PlantSEED_v3/Curation/PlantSEED_Complexes_Schema.yaml
@@ -1,0 +1,24 @@
+enzyme:
+  type: str
+  default: ''
+  required: true
+roles:
+  type: list
+  default: []
+  required: true
+compartments_reactions:
+  type: dict
+  default: {}
+  required: true
+kbase_id:
+  type: str
+  default: ''
+  required: false
+direction:
+  type: str
+  default: '='
+  required: false
+stoichiometry:
+  type: dict
+  default: {}
+  required: false

--- a/Scripts/PlantSEED_v3/Curation/Prepare_PlantSEED_KBase.py
+++ b/Scripts/PlantSEED_v3/Curation/Prepare_PlantSEED_KBase.py
@@ -1,180 +1,110 @@
 #!/usr/bin/env python
-import os,sys,json,copy
-import hashlib
-# Open database
-script_directory = os.path.dirname(os.path.abspath(sys.argv[0]))
-database_relative_path = os.path.join(script_directory, "../../../", "Data/PlantSEED_v3/")
-with open(os.path.join(database_relative_path, "PlantSEED_Roles.json")) as subsystem_file:
-	roles_list = json.load(subsystem_file)
+"""Assign KBase IDs to every role and complex in the PlantSEED database.
 
-print("+"*30)
-print("++ Checking KBase Role IDs")
-role_ID_list = list()
+Thin driver around plantseed_curation. All schema/IO/hashing logic lives in
+the shared library; this script is a two-stage pipeline:
 
-# Collect all role identifiers first
-for entry in roles_list:
-	
-	if('kbase_id' in entry):
-		if(entry['kbase_id'] in role_ID_list):
-			print("Warning, duplicate kbase_id: "+entry['kbase_id'] + " for role: "+entry['role'])
-		else:
-			role_ID_list.append(entry['kbase_id'])
+  1. Roles pass: for each role missing a `kbase_id`, mint one via
+     `assign_kbase_id` (uses role + reactions[0] + subsystems[0] for the hash).
 
-# Go back through database
-updated_roles = False
-for entry in roles_list:
+  2. Complexes pass: verify every existing complex's `kbase_id` still matches
+     what its enzyme/roles/reactions imply (via `assign_complex_kbase_id`),
+     then walk the roles JSON for any `abstract_enzyme` that isn't yet
+     represented in PlantSEED_Complexes.json and append a new complex entry
+     (via `derive_new_complexes`).
 
-	if('kbase_id' not in entry):
+Warnings/logs are collected in an `IssueCollector` and printed at the end so
+the run reads as a summary rather than interleaved output.
+"""
 
-		# check if all fields available to form unique role id
-		if('role' not in entry or 'reactions' not in entry or 'subsystems' not in entry \
-	 		or len(entry['reactions'])==0 or len(entry['subsystems'])==0):
-			print("Warning, missing role, reactions, or subsystems for role: "+entry['role'])
-			print("\tCannot create unique KBase Role ID")
-			continue
-		else:
-			# string with unique info for each role
-			# first reaction and subsystem included to differentiate spontaneous rxns
-			role_str = entry['role'] + entry['reactions'][0] + entry['subsystems'][0]
+import json
 
-			# create unique (truncated) hash ID from str and store in list
-			entry_id = 'PS_role_' + hashlib.sha256(role_str.encode('utf-8')).hexdigest()[:6]
-
-			# create new id if already in list
-			while entry_id in role_ID_list:
-				entry_id = 'PS_role_' + hashlib.sha256(entry_id.encode('utf-8')).hexdigest()[:6]
-
-			role_ID_list.append(entry_id)
-
-			entry['kbase_id'] = entry_id
-			updated_roles=True
-			pass
-
-print("+"*30)
+from plantseed_curation import (
+    assign_complex_kbase_id,
+    assign_kbase_id,
+    derive_new_complexes,
+    enzyme_index_from_complexes,
+    paths,
+)
+from plantseed_curation.schema import IssueCollector
 
 
-print("+"*30)
-print("++ Checking KBase Complex IDs")
+def _load_json(path):
+    with open(path) as fh:
+        return json.load(fh)
 
-with open(os.path.join(database_relative_path, "PlantSEED_Complexes.json")) as subsystem_file:
-	complexes_list = json.load(subsystem_file)
 
-# Collect all complex identifiers first
-update_complexes=False
-complex_ID_list = list()
-current_enzyme_dict = dict()
-for entry in complexes_list:
+def _dump_json(path, data):
+    with open(path, "w") as fh:
+        json.dump(data, fh, indent=4)
 
-	update_complex=False	
-	if('kbase_id' in entry):
-		if(entry['kbase_id'] in complex_ID_list):
-			print("Warning, duplicate kbase_id: "+entry['kbase_id'] + " for enzyme: "+entry['enzyme'])
-		else:
-			complex_ID_list.append(entry['kbase_id'])
 
-		enz = entry['enzyme']
-		if(enz not in current_enzyme_dict):
-			current_enzyme_dict[enz]={'rles':[],'rxns':[]}
+def prepare_roles(roles_list, issues):
+    """Assign a PS_role_* id to every role that lacks one. Returns True if
+    the roles list was modified."""
+    existing_ids = {r["kbase_id"] for r in roles_list if "kbase_id" in r}
+    changed = False
+    for role in roles_list:
+        if "kbase_id" in role:
+            continue
+        if assign_kbase_id(role, existing_ids, issues=issues):
+            changed = True
+    return changed
 
-		roles = sorted(entry['roles'])
-		for role in roles:
-			if(role not in current_enzyme_dict[enz]):
-				current_enzyme_dict[enz]['rles'].append(role)
 
-		rxns_cpts = list()
-		for cpt_id in entry['compartments_reactions']:
-			cpt = entry['compartments_reactions'][cpt_id]
-			for rxn in cpt['reactions']:
-				rxn_cpt = rxn+'_'+cpt_id
-				if(rxn_cpt not in current_enzyme_dict[enz]['rxns']):
-					current_enzyme_dict[enz]['rxns'].append(rxn_cpt)
-				if(rxn_cpt not in rxns_cpts):
-					rxns_cpts.append(rxn_cpt)
+def prepare_complexes(complexes_list, roles_list, issues):
+    """Verify every existing complex's id and derive a new complex entry for
+    each role whose abstract_enzyme isn't yet represented. Returns True if
+    the complexes list was modified (existing id updated OR new entry
+    appended)."""
+    existing_ids = {c["kbase_id"] for c in complexes_list if "kbase_id" in c}
+    changed = False
+    for entry in complexes_list:
+        if assign_complex_kbase_id(entry, existing_ids, issues=issues):
+            changed = True
+    enzyme_index = enzyme_index_from_complexes(complexes_list, issues=issues)
+    new_entries = derive_new_complexes(
+        roles_list, enzyme_index, existing_ids, issues=issues
+    )
+    if new_entries:
+        complexes_list.extend(new_entries)
+        changed = True
+    return changed
 
-		rxns_cpts = sorted(rxns_cpts)
-		cpx_str = " / ".join([enz,"|".join(roles),"|".join(rxns_cpts)])
-		kbase_id = 'PS_complex_' + hashlib.sha256(cpx_str.encode('utf-8')).hexdigest()[:6]
-		if(kbase_id != entry['kbase_id']):
-			print("Updating kbase_id for: ",cpx_str)
-			entry['kbase_id']=kbase_id
-			update_complex = True
-	
-	if(update_complex is True):
-		update_complexes = True
 
-# Go back through roles database and for any enzyme/role/reaction combination that doesn't have a complex id
-# and create a new complex for them
-new_enzyme_dict = dict()
-for entry in roles_list:
-	if('abstract_enzyme' not in entry):
-		print("Warning: entry with role: "+entry['role']+" doesn't have an enzyme name")
-		continue
+def _print_issues(issues):
+    for e in issues.errors:
+        print(f"ERROR: {e}")
+    for w in issues.warnings:
+        print(f"WARNING: {w}")
+    for i in issues.info:
+        print(f"INFO: {i}")
 
-	enz = entry['abstract_enzyme']
 
-	# special case of Spontaneous Reaction
-	if(enz.lower() == 'spontaneous reaction'):
-		# the entry always has a single spontaneous reaction
-		# but as there's no enzyme, we need to distinguish 
-		# between each one here
-		enz = enz+"||"+entry['reactions'][0]
+def main():
+    issues = IssueCollector()
 
-	if enz in current_enzyme_dict:
-		if(entry['role'] not in current_enzyme_dict[enz]['rles']):
-			print("Warning: role name has changed for ",enz)
-		for rxn in entry['reactions']:
-			for lcz in entry['localization']:
-				rxn_cpt = rxn+'_'+lcz
-				if(len(lcz) == 1 and rxn_cpt not in current_enzyme_dict[enz]['rxns']):
-					print("Warning: reaction has changed for ",enz,current_enzyme_dict[enz]['rxns'],rxn_cpt)
-				if(len(lcz)==2):
-					fd_rxn=False
-					for subcpt in lcz:
-						if(rxn+"_"+subcpt in current_enzyme_dict[enz]['rxns']):
-							fd_rxn=True
-					if(fd_rxn is False):
-						print("Warning: reaction has changed for ",enz,current_enzyme_dict[enz]['rxns'],rxn_cpt)
-	else:
-		print("New enzyme!")
-		# here, I'm assuming that the first time you encounter a new enzyme name
-		# is the first time you encounter the roles and reactions that should be
-		# associated with the enzyme, so any successive entries should be added here
-		if(enz not in new_enzyme_dict):
-			new_enzyme_dict[enz]={'rles':[],'rxns':[],'cpts':[]}
-		if(entry['role'] not in new_enzyme_dict[enz]['rles']):
-			new_enzyme_dict[enz]['rles'].append(entry['role'])
-		for rxn in entry['reactions']:
-			for lcz in entry['localization']:
-				rxn_cpt = rxn+"_"+lcz
-				if(rxn_cpt not in new_enzyme_dict[enz]['rxns']):
-					new_enzyme_dict[enz]['rxns'].append(rxn_cpt)
-				if(lcz not in new_enzyme_dict[enz]['cpts']):
-					new_enzyme_dict[enz]['cpts'][lcz]={'reactions':[],"reagents":lcz,"exclude":False}
-				if(rxn not in new_enzyme_dict[enz]['cpts'][lcz]['reactions']):
-					new_enzyme_dict[enz]['cpts'][lcz]['reactions'].append(rxn)
+    print("+" * 30)
+    print("++ Checking KBase Role IDs")
+    roles_list = _load_json(paths.ROLES_FILE)
+    roles_changed = prepare_roles(roles_list, issues)
 
-# re-build complexes to insert into PlantSEED_Complexes and generate a new id
-for enz in new_enzyme_dict:
-	rxns = sorted(new_enzyme_dict[enz]['rxns'])
-	rles = sorted(new_enzyme_dict[enz]['rles'])
-	cpx_str = " / ".join([enz,"|".join(rles),"|".join(rxns)])
-	kbase_id = 'PS_complex_' + hashlib.sha256(cpx_str.encode('utf-8')).hexdigest()[:6]
-	while entry_id in complex_ID_list:
-		entry_id = 'PS_role_' + hashlib.sha256(entry_id.encode('utf-8')).hexdigest()[:6]
+    print("+" * 30)
+    print("++ Checking KBase Complex IDs")
+    complexes_list = _load_json(paths.COMPLEXES_FILE)
+    complexes_changed = prepare_complexes(complexes_list, roles_list, issues)
 
-	complex = {'kbase_id':entry_id,
-			   'enzyme':enz,
-			   'roles':rles,
-			   'compartments_reactions':new_enzyme_dict['cpts']}
-	complexes_list.append(complex)
-	update_complexes=True
+    print("+" * 30)
 
-print("+"*30)
+    if roles_changed:
+        _dump_json(paths.ROLES_FILE, roles_list)
+        print(f"WROTE: {paths.ROLES_FILE}")
+    if complexes_changed:
+        _dump_json(paths.COMPLEXES_FILE, complexes_list)
+        print(f"WROTE: {paths.COMPLEXES_FILE}")
 
-if(updated_roles is True):
-	with open(os.path.join(database_relative_path, "PlantSEED_Roles.json"),'w') as new_subsystem_file:
-		json.dump(roles_list,new_subsystem_file,indent=4)
+    _print_issues(issues)
 
-if(update_complexes is True):
-	with open(os.path.join(database_relative_path, "PlantSEED_Complexes.json"),'w') as new_complex_file:
-		json.dump(complexes_list,new_complex_file,indent=4)
+
+if __name__ == "__main__":
+    main()

--- a/Scripts/PlantSEED_v3/Curation/Prepare_PlantSEED_KBase.py
+++ b/Scripts/PlantSEED_v3/Curation/Prepare_PlantSEED_KBase.py
@@ -25,6 +25,7 @@ from plantseed_curation import (
     derive_new_complexes,
     enzyme_index_from_complexes,
     paths,
+    validate_subcomplex_pointers,
 )
 from plantseed_curation.schema import IssueCollector
 
@@ -54,9 +55,10 @@ def prepare_roles(roles_list, issues):
 
 def prepare_complexes(complexes_list, roles_list, issues):
     """Verify every existing complex's id and derive a new complex entry for
-    each role whose abstract_enzyme isn't yet represented. Returns True if
-    the complexes list was modified (existing id updated OR new entry
-    appended)."""
+    each role whose abstract_enzyme isn't yet represented. Also validate that
+    every role's `subcomplex_of` (if set) points at a complex kbase_id we
+    actually have on hand. Returns True if the complexes list was modified
+    (existing id updated OR new entry appended)."""
     existing_ids = {c["kbase_id"] for c in complexes_list if "kbase_id" in c}
     changed = False
     for entry in complexes_list:
@@ -69,6 +71,10 @@ def prepare_complexes(complexes_list, roles_list, issues):
     if new_entries:
         complexes_list.extend(new_entries)
         changed = True
+    # Validate AFTER new complexes are minted so a role legitimately pointing
+    # at a fresh parent doesn't warn.
+    all_complex_ids = {c["kbase_id"] for c in complexes_list if "kbase_id" in c}
+    validate_subcomplex_pointers(roles_list, all_complex_ids, issues=issues)
     return changed
 
 

--- a/Scripts/PlantSEED_v3/Curation/plantseed_curation/__init__.py
+++ b/Scripts/PlantSEED_v3/Curation/plantseed_curation/__init__.py
@@ -35,6 +35,7 @@ from .actions import (
     run_apply,
     seed_new_entries,
     validate_payload,
+    validate_subcomplex_pointers,
 )
 from .cli_io import Console, ExitRequested
 from .constants import (
@@ -101,7 +102,8 @@ __all__ = [
     "apply_actions", "assign_complex_kbase_id", "assign_kbase_id",
     "build_tsv_rows", "complex_kbase_id", "derive_new_complexes",
     "enzyme_index_from_complexes", "enzyme_rxn_cpts", "parse_tsv_text",
-    "preview_for_enzyme", "run_apply", "seed_new_entries", "validate_payload",
+    "preview_for_enzyme", "run_apply", "seed_new_entries",
+    "validate_payload", "validate_subcomplex_pointers",
     # cli_io
     "Console", "ExitRequested",
     # constants

--- a/Scripts/PlantSEED_v3/Curation/plantseed_curation/__init__.py
+++ b/Scripts/PlantSEED_v3/Curation/plantseed_curation/__init__.py
@@ -23,8 +23,13 @@ from . import (
 # `from plantseed_curation import build_tsv_rows, ranked_search`.
 from .actions import (
     apply_actions,
+    assign_complex_kbase_id,
     assign_kbase_id,
     build_tsv_rows,
+    complex_kbase_id,
+    derive_new_complexes,
+    enzyme_index_from_complexes,
+    enzyme_rxn_cpts,
     parse_tsv_text,
     preview_for_enzyme,
     run_apply,
@@ -93,7 +98,9 @@ __all__ = [
     "actions", "cli_io", "constants", "curator_files", "expasy",
     "identity", "paths", "schema", "search", "store",
     # actions
-    "apply_actions", "assign_kbase_id", "build_tsv_rows", "parse_tsv_text",
+    "apply_actions", "assign_complex_kbase_id", "assign_kbase_id",
+    "build_tsv_rows", "complex_kbase_id", "derive_new_complexes",
+    "enzyme_index_from_complexes", "enzyme_rxn_cpts", "parse_tsv_text",
     "preview_for_enzyme", "run_apply", "seed_new_entries", "validate_payload",
     # cli_io
     "Console", "ExitRequested",

--- a/Scripts/PlantSEED_v3/Curation/plantseed_curation/actions.py
+++ b/Scripts/PlantSEED_v3/Curation/plantseed_curation/actions.py
@@ -686,6 +686,34 @@ def derive_new_complexes(roles_list, enzyme_index, existing_ids, issues=None):
     return new_complexes
 
 
+def validate_subcomplex_pointers(roles_list, complex_ids, issues=None):
+    """Walk `roles_list` and warn (via `issues`) for every role whose
+    `subcomplex_of` value is non-empty AND does not appear in `complex_ids`.
+
+    Runs AFTER all complex kbase_ids are settled (existing verified + new
+    derived) so a role that legitimately points at a freshly-minted parent
+    doesn't produce a false-positive warning.
+
+    Returns the list of (role_name, bad_pointer) tuples the caller may want
+    to surface separately from the issue stream.
+    """
+    complex_ids = set(complex_ids)
+    bad = []
+    for role in roles_list:
+        target = role.get("subcomplex_of")
+        if not target:
+            continue
+        if target not in complex_ids:
+            bad.append((role.get("role", "<unnamed>"), target))
+            if issues is not None:
+                issues.warn(
+                    f"role '{role.get('role', '<unnamed>')}' has "
+                    f"subcomplex_of={target!r} pointing at a complex "
+                    f"kbase_id not present in PlantSEED_Complexes.json"
+                )
+    return bad
+
+
 def _known_roles_for_actions(actions):
     roles = set()
     for bucket in ("replace", "add", "rem", "key", "reassign"):

--- a/Scripts/PlantSEED_v3/Curation/plantseed_curation/actions.py
+++ b/Scripts/PlantSEED_v3/Curation/plantseed_curation/actions.py
@@ -624,12 +624,42 @@ def _abstract_enzyme_key(role_entry):
     return enz
 
 
+# Transport compartment translation rules mirroring
+# Scripts/PlantSEED_v3/Template/Transport_Compartment_Rules.yaml (canonical
+# source; the two must stay in sync). Rules apply IN ORDER; each matching
+# rule overrides the previous result. The first letter of the pair is the
+# default if no rule matches. Semantics:
+#   ('if_contains', 'other') — pick the letter that is NOT if_contains
+#   ('if_contains', <literal>) — pick <literal>
+_TRANSPORT_RULES = (
+    ("c", "other"),  # non-cytosolic wins        (cv->v, cd->d, cm->m, cx->x, ce->c-via-later-rules...)
+    ("e", "other"),  # non-extracellular wins    (ce->c, de->d)
+    ("j", "j"),      # mitochondrial intermembrane wins over matrix  (mj->j)
+    ("y", "y"),      # thylakoid lumen wins over plastid stroma      (dy->y)
+)
+
+
 def _lcz_to_cpt_id(lcz):
     """Map a role's localization key to the single-letter compartment id used
-    inside a complex's compartments_reactions dict. Transport (2-letter) keys
-    collapse to their second letter, e.g. 'cv' -> 'v'. Matches the convention
-    used by every hand-authored complex in the current database."""
-    return lcz[-1] if len(lcz) > 1 else lcz
+    inside a complex's compartments_reactions dict.
+
+    1-letter codes pass through unchanged. For 2-letter transporter codes,
+    apply _TRANSPORT_RULES in order — this handles cases like `ce` -> `c`
+    (extracellular loses) that a naive `lcz[-1]` picks the wrong way.
+    """
+    if len(lcz) != 2:
+        return lcz
+    result = lcz[0]
+    for marker, target in _TRANSPORT_RULES:
+        if marker not in lcz:
+            continue
+        if target == "other":
+            for c in lcz:
+                if c != marker:
+                    result = c
+        else:
+            result = target
+    return result
 
 
 def derive_new_complexes(roles_list, enzyme_index, existing_ids, issues=None):

--- a/Scripts/PlantSEED_v3/Curation/plantseed_curation/actions.py
+++ b/Scripts/PlantSEED_v3/Curation/plantseed_curation/actions.py
@@ -523,6 +523,169 @@ def assign_kbase_id(entry, existing_ids, renamed_from=None, issues=None):
     return True
 
 
+# ----------------------------------------------------------------------------
+# Complex kbase_id assignment + derivation of new complexes from roles
+# ----------------------------------------------------------------------------
+def complex_kbase_id(enzyme, roles, rxn_cpts):
+    """PS_complex_<sha256[:6]> from enzyme name + sorted roles + sorted rxn+'_'+cpt_id keys.
+
+    Note: like `assign_kbase_id`, the hash is order-sensitive on `roles` and
+    `rxn_cpts`. Callers must sort before hashing (this helper does not sort
+    for you) so callers can be explicit about the ordering contract.
+    """
+    key = " / ".join([enzyme, "|".join(roles), "|".join(rxn_cpts)])
+    return "PS_complex_" + hashlib.sha256(key.encode("utf-8")).hexdigest()[:6]
+
+
+def enzyme_rxn_cpts(complex_entry):
+    """Return the sorted list of `rxn+'_'+cpt_id` strings used for hashing this
+    complex entry. Iterates `compartments_reactions[cpt_id].reactions` and
+    joins each reaction id to its (single-letter) compartment key."""
+    seen = []
+    for cpt_id, cpt in complex_entry.get("compartments_reactions", {}).items():
+        for rxn in cpt.get("reactions", []):
+            key = f"{rxn}_{cpt_id}"
+            if key not in seen:
+                seen.append(key)
+    return sorted(seen)
+
+
+def assign_complex_kbase_id(entry, existing_ids, issues=None):
+    """Compute the canonical PS_complex_* id for a complex entry and set it on
+    the entry. `existing_ids` is a mutable set kept in sync as we assign IDs.
+
+    Returns True if the entry's kbase_id changed (or was set for the first
+    time), False otherwise.
+    """
+    enzyme = entry.get("enzyme")
+    if not enzyme:
+        if issues is not None:
+            issues.warn("complex entry missing 'enzyme' — cannot mint kbase_id")
+        return False
+    roles = sorted(entry.get("roles", []))
+    rxn_cpts = enzyme_rxn_cpts(entry)
+    old_id = entry.get("kbase_id")
+    new_id = complex_kbase_id(enzyme, roles, rxn_cpts)
+    pool = set(existing_ids)
+    if old_id in pool:
+        pool.discard(old_id)
+    while new_id in pool:
+        new_id = "PS_complex_" + hashlib.sha256(new_id.encode("utf-8")).hexdigest()[:6]
+    if new_id == old_id:
+        return False
+    entry["kbase_id"] = new_id
+    if old_id:
+        existing_ids.discard(old_id)
+    existing_ids.add(new_id)
+    if issues is not None and old_id:
+        issues.log(
+            f"complex kbase_id changed for enzyme '{enzyme}' (was {old_id}, now {new_id})"
+        )
+    return True
+
+
+def enzyme_index_from_complexes(complexes_list, issues=None):
+    """Build `{enzyme: {'roles': [...], 'rxn_cpts': [...]}}` lookup from an
+    existing complexes list. Warns via `issues` on duplicate kbase_ids."""
+    index = {}
+    seen_ids = set()
+    for entry in complexes_list:
+        kid = entry.get("kbase_id")
+        if kid:
+            if kid in seen_ids and issues is not None:
+                issues.warn(
+                    f"duplicate complex kbase_id: {kid} for enzyme: {entry.get('enzyme')}"
+                )
+            seen_ids.add(kid)
+        enz = entry.get("enzyme")
+        if not enz:
+            continue
+        bucket = index.setdefault(enz, {"roles": [], "rxn_cpts": []})
+        for role in entry.get("roles", []):
+            if role not in bucket["roles"]:
+                bucket["roles"].append(role)
+        for rxn_cpt in enzyme_rxn_cpts(entry):
+            if rxn_cpt not in bucket["rxn_cpts"]:
+                bucket["rxn_cpts"].append(rxn_cpt)
+    return index
+
+
+def _abstract_enzyme_key(role_entry):
+    """Return the abstract enzyme name for grouping, applying the
+    spontaneous-reaction disambiguation. Returns None if the role has no
+    abstract_enzyme set."""
+    enz = role_entry.get("abstract_enzyme")
+    if not enz:
+        return None
+    if enz.strip().lower() == "spontaneous reaction":
+        rxns = role_entry.get("reactions", [])
+        if rxns:
+            enz = f"{enz}||{rxns[0]}"
+    return enz
+
+
+def _lcz_to_cpt_id(lcz):
+    """Map a role's localization key to the single-letter compartment id used
+    inside a complex's compartments_reactions dict. Transport (2-letter) keys
+    collapse to their second letter, e.g. 'cv' -> 'v'. Matches the convention
+    used by every hand-authored complex in the current database."""
+    return lcz[-1] if len(lcz) > 1 else lcz
+
+
+def derive_new_complexes(roles_list, enzyme_index, existing_ids, issues=None):
+    """For every role whose `abstract_enzyme` (with spontaneous-reaction
+    disambiguation) is NOT already in `enzyme_index`, build a new complex
+    entry with a fresh PS_complex_* kbase_id.
+
+    Returns the list of new complex dicts (each ready to append to
+    PlantSEED_Complexes.json). `existing_ids` is mutated as new ids are
+    minted so duplicates are avoided across successive calls.
+
+    Roles missing `reactions` or `localization` are skipped (they cannot
+    contribute a well-formed complex).
+    """
+    per_enzyme = {}  # enzyme -> {'roles': [], 'rxn_cpts': [], 'cpts': {}}
+    for role in roles_list:
+        enz = _abstract_enzyme_key(role)
+        if not enz or enz in enzyme_index:
+            continue
+        if not role.get("reactions") or not role.get("localization"):
+            continue
+        bucket = per_enzyme.setdefault(enz, {"roles": [], "rxn_cpts": [], "cpts": {}})
+        if role["role"] not in bucket["roles"]:
+            bucket["roles"].append(role["role"])
+        for rxn in role["reactions"]:
+            for lcz in role["localization"]:
+                cpt_id = _lcz_to_cpt_id(lcz)
+                rxn_cpt = f"{rxn}_{cpt_id}"
+                if rxn_cpt not in bucket["rxn_cpts"]:
+                    bucket["rxn_cpts"].append(rxn_cpt)
+                cpt_bucket = bucket["cpts"].setdefault(
+                    cpt_id,
+                    {"reactions": [], "reagents": lcz, "exclude": False},
+                )
+                if rxn not in cpt_bucket["reactions"]:
+                    cpt_bucket["reactions"].append(rxn)
+    new_complexes = []
+    for enz, bucket in per_enzyme.items():
+        roles = sorted(bucket["roles"])
+        rxn_cpts = sorted(bucket["rxn_cpts"])
+        kid = complex_kbase_id(enz, roles, rxn_cpts)
+        pool = set(existing_ids)
+        while kid in pool:
+            kid = "PS_complex_" + hashlib.sha256(kid.encode("utf-8")).hexdigest()[:6]
+        existing_ids.add(kid)
+        new_complexes.append({
+            "kbase_id": kid,
+            "enzyme": enz,
+            "roles": roles,
+            "compartments_reactions": bucket["cpts"],
+        })
+        if issues is not None:
+            issues.log(f"new complex minted for enzyme '{enz}' as {kid}")
+    return new_complexes
+
+
 def _known_roles_for_actions(actions):
     roles = set()
     for bucket in ("replace", "add", "rem", "key", "reassign"):

--- a/Scripts/PlantSEED_v3/Curation/plantseed_curation/paths.py
+++ b/Scripts/PlantSEED_v3/Curation/plantseed_curation/paths.py
@@ -26,6 +26,10 @@ ROLES_FILE = _env(
     "PLANTSEED_ROLES_FILE",
     os.path.join(_REPO_ROOT, "Data", "PlantSEED_v3", "PlantSEED_Roles.json"),
 )
+COMPLEXES_FILE = _env(
+    "PLANTSEED_COMPLEXES_FILE",
+    os.path.join(_REPO_ROOT, "Data", "PlantSEED_v3", "PlantSEED_Complexes.json"),
+)
 SCHEMA_FILE = _env("PLANTSEED_SCHEMA_FILE", os.path.join(BASE_DIR, "PlantSEED_Schema.yaml"))
 CURATORS_DIR = _env("PLANTSEED_CURATORS_DIR", os.path.join(BASE_DIR, "Curators"))
 CURATOR_REGISTRY = _env(
@@ -44,12 +48,16 @@ def refresh_from_env():
     """Re-read paths from the environment. Tests call this after setting
     PLANTSEED_* env vars in a fixture so the module-level constants reflect
     the new values."""
-    global BASE_DIR, ROLES_FILE, SCHEMA_FILE, CURATORS_DIR, CURATOR_REGISTRY
+    global BASE_DIR, ROLES_FILE, COMPLEXES_FILE, SCHEMA_FILE, CURATORS_DIR, CURATOR_REGISTRY
     global ENZYME_DAT_URL, ENZYME_DAT_CACHE
     BASE_DIR = _env("PLANTSEED_BASE_DIR", _CURATION_ROOT)
     ROLES_FILE = _env(
         "PLANTSEED_ROLES_FILE",
         os.path.join(_REPO_ROOT, "Data", "PlantSEED_v3", "PlantSEED_Roles.json"),
+    )
+    COMPLEXES_FILE = _env(
+        "PLANTSEED_COMPLEXES_FILE",
+        os.path.join(_REPO_ROOT, "Data", "PlantSEED_v3", "PlantSEED_Complexes.json"),
     )
     SCHEMA_FILE = _env("PLANTSEED_SCHEMA_FILE", os.path.join(BASE_DIR, "PlantSEED_Schema.yaml"))
     CURATORS_DIR = _env("PLANTSEED_CURATORS_DIR", os.path.join(BASE_DIR, "Curators"))

--- a/Scripts/PlantSEED_v3/Curation/tests/conftest.py
+++ b/Scripts/PlantSEED_v3/Curation/tests/conftest.py
@@ -21,23 +21,27 @@ sys.path.insert(0, CURATION_ROOT)
 
 FIXTURES = os.path.join(HERE, "fixtures")
 MINI_ROLES = os.path.join(FIXTURES, "mini_roles.json")
+MINI_COMPLEXES = os.path.join(FIXTURES, "mini_complexes.json")
 MINI_SCHEMA = os.path.join(FIXTURES, "mini_schema.yaml")
 
 
 def _seed_tmp_db(tmp_root):
-    """Copy fixture files into a tmp tree and return the four path strings."""
+    """Copy fixture files into a tmp tree and return the path dict."""
     roles = os.path.join(tmp_root, "PlantSEED_Roles.json")
+    complexes = os.path.join(tmp_root, "PlantSEED_Complexes.json")
     schema = os.path.join(tmp_root, "PlantSEED_Schema.yaml")
     curators = os.path.join(tmp_root, "Curators")
     os.makedirs(curators, exist_ok=True)
     shutil.copy(MINI_ROLES, roles)
+    shutil.copy(MINI_COMPLEXES, complexes)
     shutil.copy(MINI_SCHEMA, schema)
     return {
-        "base":     tmp_root,
-        "roles":    roles,
-        "schema":   schema,
-        "curators": curators,
-        "registry": os.path.join(curators, "curator_registry.json"),
+        "base":      tmp_root,
+        "roles":     roles,
+        "complexes": complexes,
+        "schema":    schema,
+        "curators":  curators,
+        "registry":  os.path.join(curators, "curator_registry.json"),
     }
 
 
@@ -47,6 +51,7 @@ def tmp_db(tmp_path, monkeypatch):
     paths_dict = _seed_tmp_db(str(tmp_path))
     monkeypatch.setenv("PLANTSEED_BASE_DIR",         paths_dict["base"])
     monkeypatch.setenv("PLANTSEED_ROLES_FILE",       paths_dict["roles"])
+    monkeypatch.setenv("PLANTSEED_COMPLEXES_FILE",   paths_dict["complexes"])
     monkeypatch.setenv("PLANTSEED_SCHEMA_FILE",      paths_dict["schema"])
     monkeypatch.setenv("PLANTSEED_CURATORS_DIR",     paths_dict["curators"])
     monkeypatch.setenv("PLANTSEED_CURATOR_REGISTRY", paths_dict["registry"])

--- a/Scripts/PlantSEED_v3/Curation/tests/fixtures/mini_complexes.json
+++ b/Scripts/PlantSEED_v3/Curation/tests/fixtures/mini_complexes.json
@@ -1,0 +1,10 @@
+[
+    {
+        "kbase_id": "PS_complex_alpha1",
+        "enzyme": "Alpha enzyme",
+        "roles": ["Alpha enzyme (EC 1.1.1.1)"],
+        "compartments_reactions": {
+            "c": {"reactions": ["rxn00001"], "reagents": "c", "exclude": false}
+        }
+    }
+]

--- a/Scripts/PlantSEED_v3/Curation/tests/test_complexes.py
+++ b/Scripts/PlantSEED_v3/Curation/tests/test_complexes.py
@@ -231,6 +231,53 @@ def test_derive_new_complexes_2letter_localization_uses_second_letter_key():
     assert cr["v"]["reactions"] == ["rxnT"]
 
 
+# ---------- _lcz_to_cpt_id transport-rule cases ------------------------------
+@pytest.mark.parametrize("lcz, expected", [
+    # 1-letter codes pass through
+    ("c", "c"), ("d", "d"), ("m", "m"), ("x", "x"), ("v", "v"),
+    # 2-letter cases from Transport_Compartment_Rules.yaml
+    ("cv", "v"),  # non-cytosolic wins
+    ("cd", "d"),
+    ("cm", "m"),
+    ("cx", "x"),
+    ("ce", "c"),  # non-extracellular wins (rule 2 overrides rule 1)
+    ("de", "d"),  # non-extracellular wins
+    ("dy", "y"),  # thylakoid lumen wins over plastid stroma
+    ("mj", "j"),  # intermembrane wins over matrix
+])
+def test_lcz_to_cpt_id_matches_transport_rules_yaml(lcz, expected):
+    assert A._lcz_to_cpt_id(lcz) == expected
+
+
+def test_lcz_to_cpt_id_falls_back_to_first_letter_for_unknown_pair():
+    """A 2-letter code with no rule triggers uses the first letter."""
+    assert A._lcz_to_cpt_id("ab") == "a"
+
+
+def test_transport_rules_stay_in_sync_with_yaml():
+    """If Transport_Compartment_Rules.yaml is edited, the hardcoded
+    _TRANSPORT_RULES tuple in actions.py must be edited too. This test
+    fails when they drift."""
+    import os
+    import yaml
+    # actions.py lives at Scripts/PlantSEED_v3/Curation/plantseed_curation/actions.py.
+    # The yaml lives at   Scripts/PlantSEED_v3/Template/Transport_Compartment_Rules.yaml.
+    # So: two `..` back to PlantSEED_v3, then into Template/.
+    yaml_path = os.path.normpath(os.path.join(
+        os.path.dirname(A.__file__), "..", "..",
+        "Template", "Transport_Compartment_Rules.yaml",
+    ))
+    if not os.path.isfile(yaml_path):
+        pytest.skip(f"yaml source-of-truth not present at {yaml_path}")
+    with open(yaml_path) as f:
+        data = yaml.safe_load(f)
+    yaml_rules = [(r["if_contains"], r["result"]) for r in data["rules"]]
+    assert list(A._TRANSPORT_RULES) == yaml_rules, (
+        f"_TRANSPORT_RULES ({A._TRANSPORT_RULES}) drifted from "
+        f"Transport_Compartment_Rules.yaml ({yaml_rules}). Edit both."
+    )
+
+
 def test_derive_new_complexes_merges_multiple_roles_for_same_enzyme():
     roles = [
         _role("R1", "Enz", ["rxn1"], ["c"]),

--- a/Scripts/PlantSEED_v3/Curation/tests/test_complexes.py
+++ b/Scripts/PlantSEED_v3/Curation/tests/test_complexes.py
@@ -1,0 +1,262 @@
+"""complex_kbase_id, assign_complex_kbase_id, enzyme_index_from_complexes,
+derive_new_complexes — the complex-side of the KBase-ID plumbing that
+Prepare_PlantSEED_KBase.py drives."""
+
+import hashlib
+import json
+
+import pytest
+
+from plantseed_curation import actions as A
+from plantseed_curation.schema import IssueCollector
+
+
+# ---------- complex_kbase_id (pure hash) -------------------------------------
+def test_complex_kbase_id_is_deterministic():
+    a = A.complex_kbase_id("Enz", ["Role1"], ["rxnA_c"])
+    b = A.complex_kbase_id("Enz", ["Role1"], ["rxnA_c"])
+    assert a == b
+    assert a.startswith("PS_complex_")
+    assert len(a) == len("PS_complex_") + 6
+
+
+def test_complex_kbase_id_order_sensitive():
+    """Callers must sort — helper does not."""
+    a = A.complex_kbase_id("Enz", ["R1", "R2"], ["rxnA_c"])
+    b = A.complex_kbase_id("Enz", ["R2", "R1"], ["rxnA_c"])
+    assert a != b
+
+
+def test_complex_kbase_id_matches_manual_hash():
+    key = "Enz / R1|R2 / rxnA_c|rxnB_d"
+    expected = "PS_complex_" + hashlib.sha256(key.encode()).hexdigest()[:6]
+    assert A.complex_kbase_id("Enz", ["R1", "R2"], ["rxnA_c", "rxnB_d"]) == expected
+
+
+# ---------- enzyme_rxn_cpts --------------------------------------------------
+def test_enzyme_rxn_cpts_from_single_compartment():
+    entry = {
+        "compartments_reactions": {
+            "c": {"reactions": ["rxn1"], "reagents": "c", "exclude": False}
+        }
+    }
+    assert A.enzyme_rxn_cpts(entry) == ["rxn1_c"]
+
+
+def test_enzyme_rxn_cpts_sorts_and_dedupes():
+    entry = {
+        "compartments_reactions": {
+            "d": {"reactions": ["rxnB", "rxnA"], "reagents": "d", "exclude": False},
+            "c": {"reactions": ["rxnA"], "reagents": "c", "exclude": False},
+        }
+    }
+    assert A.enzyme_rxn_cpts(entry) == ["rxnA_c", "rxnA_d", "rxnB_d"]
+
+
+def test_enzyme_rxn_cpts_empty_when_no_compartments_reactions():
+    assert A.enzyme_rxn_cpts({}) == []
+
+
+# ---------- assign_complex_kbase_id ------------------------------------------
+def test_assign_complex_kbase_id_leaves_matching_id_alone():
+    entry = {
+        "enzyme": "Alpha enzyme",
+        "roles": ["Alpha enzyme (EC 1.1.1.1)"],
+        "compartments_reactions": {
+            "c": {"reactions": ["rxn00001"], "reagents": "c", "exclude": False}
+        },
+    }
+    canonical = A.complex_kbase_id(
+        "Alpha enzyme", sorted(entry["roles"]), A.enzyme_rxn_cpts(entry)
+    )
+    entry["kbase_id"] = canonical
+    existing = {canonical}
+    changed = A.assign_complex_kbase_id(entry, existing)
+    assert changed is False
+    assert entry["kbase_id"] == canonical
+
+
+def test_assign_complex_kbase_id_rehashes_when_roles_change():
+    entry = {
+        "kbase_id": "PS_complex_stale1",
+        "enzyme": "Enz",
+        "roles": ["R1", "R2"],
+        "compartments_reactions": {
+            "c": {"reactions": ["rxn1"], "reagents": "c", "exclude": False}
+        },
+    }
+    existing = {"PS_complex_stale1"}
+    issues = IssueCollector()
+    changed = A.assign_complex_kbase_id(entry, existing, issues=issues)
+    assert changed is True
+    assert entry["kbase_id"] != "PS_complex_stale1"
+    assert entry["kbase_id"] in existing
+    assert "PS_complex_stale1" not in existing
+    assert any("kbase_id changed" in m for m in issues.info)
+
+
+def test_assign_complex_kbase_id_missing_enzyme_warns_and_no_change():
+    entry = {"roles": ["R"], "compartments_reactions": {}}
+    existing = set()
+    issues = IssueCollector()
+    changed = A.assign_complex_kbase_id(entry, existing, issues=issues)
+    assert changed is False
+    assert "kbase_id" not in entry
+    assert issues.warnings
+
+
+def test_assign_complex_kbase_id_resolves_collision():
+    entry = {
+        "enzyme": "Enz",
+        "roles": ["R1"],
+        "compartments_reactions": {
+            "c": {"reactions": ["rxn1"], "reagents": "c", "exclude": False}
+        },
+    }
+    canonical = A.complex_kbase_id(
+        "Enz", ["R1"], A.enzyme_rxn_cpts(entry)
+    )
+    # Occupy the canonical id under a different enzyme so we force a rehash.
+    existing = {canonical}
+    changed = A.assign_complex_kbase_id(entry, existing)
+    assert changed is True
+    assert entry["kbase_id"] != canonical
+    assert entry["kbase_id"] in existing
+
+
+# ---------- enzyme_index_from_complexes --------------------------------------
+def test_enzyme_index_collects_roles_and_rxn_cpts():
+    complexes = [
+        {
+            "kbase_id": "PS_complex_a",
+            "enzyme": "Enz",
+            "roles": ["R1"],
+            "compartments_reactions": {
+                "c": {"reactions": ["rxn1"], "reagents": "c", "exclude": False}
+            },
+        },
+        {
+            "kbase_id": "PS_complex_b",
+            "enzyme": "Enz",
+            "roles": ["R2"],
+            "compartments_reactions": {
+                "d": {"reactions": ["rxn2"], "reagents": "d", "exclude": False}
+            },
+        },
+    ]
+    idx = A.enzyme_index_from_complexes(complexes)
+    assert set(idx.keys()) == {"Enz"}
+    assert set(idx["Enz"]["roles"]) == {"R1", "R2"}
+    assert set(idx["Enz"]["rxn_cpts"]) == {"rxn1_c", "rxn2_d"}
+
+
+def test_enzyme_index_flags_duplicate_kbase_id():
+    complexes = [
+        {"kbase_id": "PS_complex_dup", "enzyme": "A", "roles": [], "compartments_reactions": {}},
+        {"kbase_id": "PS_complex_dup", "enzyme": "B", "roles": [], "compartments_reactions": {}},
+    ]
+    issues = IssueCollector()
+    A.enzyme_index_from_complexes(complexes, issues=issues)
+    assert any("duplicate complex kbase_id" in w for w in issues.warnings)
+
+
+# ---------- derive_new_complexes ---------------------------------------------
+def _role(name, enz, rxns, lczs, sub="S"):
+    return {
+        "role":            name,
+        "abstract_enzyme": enz,
+        "reactions":       list(rxns),
+        "subsystems":      [sub],
+        "localization":    {l: {} for l in lczs},
+    }
+
+
+def test_derive_new_complexes_adds_missing_enzyme():
+    roles = [
+        _role("Delta enzyme (EC 4.4.4.4)", "Delta enzyme", ["rxn00004"], ["c"]),
+    ]
+    idx = {}  # nothing in complexes yet
+    existing_ids = set()
+    new = A.derive_new_complexes(roles, idx, existing_ids)
+    assert len(new) == 1
+    entry = new[0]
+    assert entry["enzyme"] == "Delta enzyme"
+    assert entry["roles"] == ["Delta enzyme (EC 4.4.4.4)"]
+    assert entry["compartments_reactions"] == {
+        "c": {"reactions": ["rxn00004"], "reagents": "c", "exclude": False}
+    }
+    assert entry["kbase_id"].startswith("PS_complex_")
+    assert entry["kbase_id"] in existing_ids
+
+
+def test_derive_new_complexes_skips_existing_enzyme():
+    roles = [_role("R", "Enz", ["rxn1"], ["c"])]
+    idx = {"Enz": {"roles": ["R"], "rxn_cpts": ["rxn1_c"]}}
+    new = A.derive_new_complexes(roles, idx, set())
+    assert new == []
+
+
+def test_derive_new_complexes_skips_role_without_reactions_or_localization():
+    roles = [
+        _role("no-rxn", "Enz1", [], ["c"]),
+        _role("no-lcz", "Enz2", ["rxn1"], []),
+    ]
+    new = A.derive_new_complexes(roles, {}, set())
+    assert new == []
+
+
+def test_derive_new_complexes_disambiguates_spontaneous_reaction():
+    """Two 'Spontaneous Reaction' roles with different reactions should produce
+    two distinct complex entries."""
+    roles = [
+        _role("Sp1", "Spontaneous Reaction", ["rxn0001"], ["c"]),
+        _role("Sp2", "Spontaneous Reaction", ["rxn0002"], ["c"]),
+    ]
+    new = A.derive_new_complexes(roles, {}, set())
+    assert len(new) == 2
+    enzymes = {e["enzyme"] for e in new}
+    assert enzymes == {"Spontaneous Reaction||rxn0001", "Spontaneous Reaction||rxn0002"}
+
+
+def test_derive_new_complexes_2letter_localization_uses_second_letter_key():
+    """A 'cv' transport role should produce a complex with cpt key 'v' and
+    reagents 'cv' — matching how every hand-authored transport complex is
+    structured today."""
+    roles = [_role("T", "Transporter", ["rxnT"], ["cv"])]
+    new = A.derive_new_complexes(roles, {}, set())
+    assert len(new) == 1
+    cr = new[0]["compartments_reactions"]
+    assert list(cr.keys()) == ["v"]
+    assert cr["v"]["reagents"] == "cv"
+    assert cr["v"]["reactions"] == ["rxnT"]
+
+
+def test_derive_new_complexes_merges_multiple_roles_for_same_enzyme():
+    roles = [
+        _role("R1", "Enz", ["rxn1"], ["c"]),
+        _role("R2", "Enz", ["rxn2"], ["c"]),
+    ]
+    new = A.derive_new_complexes(roles, {}, set())
+    assert len(new) == 1
+    entry = new[0]
+    assert entry["enzyme"] == "Enz"
+    assert entry["roles"] == ["R1", "R2"]  # sorted
+    assert set(entry["compartments_reactions"]["c"]["reactions"]) == {"rxn1", "rxn2"}
+
+
+def test_derive_new_complexes_kbase_id_matches_pure_hash():
+    roles = [_role("Solo (EC 5.5.5.5)", "Solo", ["rxnX"], ["c"])]
+    new = A.derive_new_complexes(roles, {}, set())
+    expected = A.complex_kbase_id("Solo", ["Solo (EC 5.5.5.5)"], ["rxnX_c"])
+    assert new[0]["kbase_id"] == expected
+
+
+# ---------- integration: paths + full driver bits ----------------------------
+def test_complexes_file_env_override(tmp_db):
+    """PLANTSEED_COMPLEXES_FILE gets picked up by the paths module and points
+    at the tmp fixture, not the real database."""
+    from plantseed_curation import paths as p
+    assert p.COMPLEXES_FILE == tmp_db["complexes"]
+    with open(p.COMPLEXES_FILE) as fh:
+        data = json.load(fh)
+    assert data[0]["enzyme"] == "Alpha enzyme"

--- a/Scripts/PlantSEED_v3/Curation/tests/test_complexes.py
+++ b/Scripts/PlantSEED_v3/Curation/tests/test_complexes.py
@@ -251,6 +251,65 @@ def test_derive_new_complexes_kbase_id_matches_pure_hash():
     assert new[0]["kbase_id"] == expected
 
 
+# ---------- validate_subcomplex_pointers -------------------------------------
+def test_validate_subcomplex_pointers_empty_target_is_ok():
+    """Roles with no subcomplex_of (or an empty string) never warn."""
+    roles = [
+        {"role": "R1"},                       # field absent
+        {"role": "R2", "subcomplex_of": ""},  # field empty
+    ]
+    issues = IssueCollector()
+    bad = A.validate_subcomplex_pointers(roles, set(), issues=issues)
+    assert bad == []
+    assert issues.warnings == []
+
+
+def test_validate_subcomplex_pointers_present_target_is_ok():
+    roles = [{"role": "R1", "subcomplex_of": "PS_complex_parent"}]
+    issues = IssueCollector()
+    bad = A.validate_subcomplex_pointers(roles, {"PS_complex_parent"}, issues=issues)
+    assert bad == []
+    assert issues.warnings == []
+
+
+def test_validate_subcomplex_pointers_missing_target_warns():
+    roles = [
+        {"role": "R1", "subcomplex_of": "PS_complex_ghost"},
+        {"role": "R2", "subcomplex_of": "PS_complex_also_missing"},
+    ]
+    issues = IssueCollector()
+    bad = A.validate_subcomplex_pointers(roles, {"PS_complex_parent"}, issues=issues)
+    assert bad == [
+        ("R1", "PS_complex_ghost"),
+        ("R2", "PS_complex_also_missing"),
+    ]
+    assert len(issues.warnings) == 2
+    assert any("PS_complex_ghost" in w for w in issues.warnings)
+
+
+def test_validate_subcomplex_pointers_accepts_freshly_derived_parent():
+    """The validation must run AFTER derive_new_complexes so a role pointing
+    at a parent that was just minted this run doesn't warn."""
+    roles = [
+        _role("Parent role", "ParentEnz", ["rxn1"], ["c"]),
+        {"role":            "Child role",
+         "subcomplex_of":   None,  # placeholder, filled in below
+         "abstract_enzyme": "ChildEnz",
+         "reactions":       ["rxn2"],
+         "subsystems":      ["S"],
+         "localization":    {"c": {}}},
+    ]
+    existing_ids = set()
+    new = A.derive_new_complexes(roles, {}, existing_ids)
+    parent_id = next(c["kbase_id"] for c in new if c["enzyme"] == "ParentEnz")
+    roles[1]["subcomplex_of"] = parent_id  # now legitimately points at the fresh parent
+    all_ids = {c["kbase_id"] for c in new}
+    issues = IssueCollector()
+    bad = A.validate_subcomplex_pointers(roles, all_ids, issues=issues)
+    assert bad == []
+    assert issues.warnings == []
+
+
 # ---------- integration: paths + full driver bits ----------------------------
 def test_complexes_file_env_override(tmp_db):
     """PLANTSEED_COMPLEXES_FILE gets picked up by the paths module and points

--- a/Scripts/PlantSEED_v3/Template/PlantSEED_Neutral_Template.json
+++ b/Scripts/PlantSEED_v3/Template/PlantSEED_Neutral_Template.json
@@ -20318,7 +20318,7 @@
             "templatecompartment_ref": "~/compartments/id/c",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -20386,7 +20386,7 @@
             "templatecompartment_ref": "~/compartments/id/c",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -20570,7 +20570,7 @@
             "templatecompartment_ref": "~/compartments/id/d",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -20862,7 +20862,7 @@
             "templatecompartment_ref": "~/compartments/id/d",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -21006,7 +21006,7 @@
             "templatecompartment_ref": "~/compartments/id/c",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -21050,7 +21050,7 @@
             "templatecompartment_ref": "~/compartments/id/d",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -21094,7 +21094,7 @@
             "templatecompartment_ref": "~/compartments/id/m",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -23796,7 +23796,7 @@
             "templatecompartment_ref": "~/compartments/id/d",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -25030,7 +25030,7 @@
             "templatecompartment_ref": "~/compartments/id/c",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -25075,7 +25075,7 @@
             "templatecompartment_ref": "~/compartments/id/d",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -27925,7 +27925,7 @@
             "templatecompartment_ref": "~/compartments/id/d",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -27969,7 +27969,7 @@
             "templatecompartment_ref": "~/compartments/id/r",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -28013,7 +28013,7 @@
             "templatecompartment_ref": "~/compartments/id/x",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -29237,7 +29237,7 @@
             "templatecompartment_ref": "~/compartments/id/c",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -30561,7 +30561,7 @@
             "templatecompartment_ref": "~/compartments/id/c",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -31692,7 +31692,7 @@
             "templatecompartment_ref": "~/compartments/id/c",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -32044,7 +32044,7 @@
             "templatecompartment_ref": "~/compartments/id/c",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -34092,7 +34092,7 @@
             "templatecompartment_ref": "~/compartments/id/m",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -34303,7 +34303,7 @@
                 }
             ],
             "templatecomplex_refs": [
-                "~/complexes/id/PS_complex_5831c7"
+                "~/complexes/id/PS_complex_69ea3e"
             ]
         },
         {
@@ -34456,7 +34456,7 @@
             "templatecompartment_ref": "~/compartments/id/d",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": "=",
+            "direction": ">",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -34624,7 +34624,7 @@
             "templatecompartment_ref": "~/compartments/id/c",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -40405,7 +40405,7 @@
             "templatecompartment_ref": "~/compartments/id/d",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -40449,7 +40449,7 @@
             "templatecompartment_ref": "~/compartments/id/r",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -40493,7 +40493,7 @@
             "templatecompartment_ref": "~/compartments/id/x",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -43994,7 +43994,7 @@
             "templatecompartment_ref": "~/compartments/id/d",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -44038,7 +44038,7 @@
             "templatecompartment_ref": "~/compartments/id/r",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -44082,7 +44082,7 @@
             "templatecompartment_ref": "~/compartments/id/x",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -44126,7 +44126,7 @@
             "templatecompartment_ref": "~/compartments/id/d",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -44170,7 +44170,7 @@
             "templatecompartment_ref": "~/compartments/id/r",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -44214,7 +44214,7 @@
             "templatecompartment_ref": "~/compartments/id/x",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -44258,7 +44258,7 @@
             "templatecompartment_ref": "~/compartments/id/d",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -44302,7 +44302,7 @@
             "templatecompartment_ref": "~/compartments/id/r",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -44346,7 +44346,7 @@
             "templatecompartment_ref": "~/compartments/id/x",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -45742,7 +45742,7 @@
                 }
             ],
             "templatecomplex_refs": [
-                "~/complexes/id/PS_complex_5831c7"
+                "~/complexes/id/PS_complex_69ea3e"
             ]
         },
         {
@@ -45890,7 +45890,7 @@
                 }
             ],
             "templatecomplex_refs": [
-                "~/complexes/id/PS_complex_1374b1"
+                "~/complexes/id/PS_complex_3ee0b3"
             ]
         },
         {
@@ -45935,7 +45935,7 @@
             "templatecompartment_ref": "~/compartments/id/d",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -45979,7 +45979,7 @@
             "templatecompartment_ref": "~/compartments/id/r",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -46023,7 +46023,7 @@
             "templatecompartment_ref": "~/compartments/id/x",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -47043,7 +47043,7 @@
                 }
             ],
             "templatecomplex_refs": [
-                "~/complexes/id/PS_complex_1374b1"
+                "~/complexes/id/PS_complex_3ee0b3"
             ]
         },
         {
@@ -47307,7 +47307,7 @@
                 }
             ],
             "templatecomplex_refs": [
-                "~/complexes/id/PS_complex_5831c7"
+                "~/complexes/id/PS_complex_69ea3e"
             ]
         },
         {
@@ -48014,7 +48014,7 @@
                 }
             ],
             "templatecomplex_refs": [
-                "~/complexes/id/PS_complex_5831c7"
+                "~/complexes/id/PS_complex_69ea3e"
             ]
         },
         {
@@ -50403,7 +50403,7 @@
             "templatecompartment_ref": "~/compartments/id/d",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -50447,7 +50447,7 @@
             "templatecompartment_ref": "~/compartments/id/r",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -50491,7 +50491,7 @@
             "templatecompartment_ref": "~/compartments/id/x",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -52037,7 +52037,7 @@
                 }
             ],
             "templatecomplex_refs": [
-                "~/complexes/id/PS_complex_82bdcd"
+                "~/complexes/id/PS_complex_2a49f5"
             ]
         },
         {
@@ -52077,7 +52077,7 @@
                 }
             ],
             "templatecomplex_refs": [
-                "~/complexes/id/PS_complex_82bdcd"
+                "~/complexes/id/PS_complex_2a49f5"
             ]
         },
         {
@@ -52117,7 +52117,7 @@
                 }
             ],
             "templatecomplex_refs": [
-                "~/complexes/id/PS_complex_82bdcd"
+                "~/complexes/id/PS_complex_2a49f5"
             ]
         },
         {
@@ -52157,7 +52157,7 @@
                 }
             ],
             "templatecomplex_refs": [
-                "~/complexes/id/PS_complex_82bdcd"
+                "~/complexes/id/PS_complex_2a49f5"
             ]
         },
         {
@@ -52197,7 +52197,7 @@
                 }
             ],
             "templatecomplex_refs": [
-                "~/complexes/id/PS_complex_82bdcd"
+                "~/complexes/id/PS_complex_2a49f5"
             ]
         },
         {
@@ -52237,7 +52237,7 @@
                 }
             ],
             "templatecomplex_refs": [
-                "~/complexes/id/PS_complex_82bdcd"
+                "~/complexes/id/PS_complex_2a49f5"
             ]
         },
         {
@@ -52557,7 +52557,7 @@
                 }
             ],
             "templatecomplex_refs": [
-                "~/complexes/id/PS_complex_f80bf6"
+                "~/complexes/id/PS_complex_660e96"
             ]
         },
         {
@@ -52589,7 +52589,7 @@
                 }
             ],
             "templatecomplex_refs": [
-                "~/complexes/id/PS_complex_f80bf6"
+                "~/complexes/id/PS_complex_660e96"
             ]
         },
         {
@@ -52621,7 +52621,7 @@
                 }
             ],
             "templatecomplex_refs": [
-                "~/complexes/id/PS_complex_f80bf6"
+                "~/complexes/id/PS_complex_660e96"
             ]
         },
         {
@@ -52653,7 +52653,7 @@
                 }
             ],
             "templatecomplex_refs": [
-                "~/complexes/id/PS_complex_f80bf6"
+                "~/complexes/id/PS_complex_660e96"
             ]
         },
         {
@@ -52685,7 +52685,7 @@
                 }
             ],
             "templatecomplex_refs": [
-                "~/complexes/id/PS_complex_f80bf6"
+                "~/complexes/id/PS_complex_660e96"
             ]
         },
         {
@@ -52717,7 +52717,7 @@
                 }
             ],
             "templatecomplex_refs": [
-                "~/complexes/id/PS_complex_f80bf6"
+                "~/complexes/id/PS_complex_660e96"
             ]
         },
         {
@@ -52749,7 +52749,7 @@
                 }
             ],
             "templatecomplex_refs": [
-                "~/complexes/id/PS_complex_f80bf6"
+                "~/complexes/id/PS_complex_660e96"
             ]
         },
         {
@@ -52781,7 +52781,7 @@
                 }
             ],
             "templatecomplex_refs": [
-                "~/complexes/id/PS_complex_f80bf6"
+                "~/complexes/id/PS_complex_660e96"
             ]
         },
         {
@@ -54317,7 +54317,7 @@
                 }
             ],
             "templatecomplex_refs": [
-                "~/complexes/id/PS_complex_1374b1"
+                "~/complexes/id/PS_complex_3ee0b3"
             ]
         },
         {
@@ -55102,7 +55102,7 @@
             "templatecompartment_ref": "~/compartments/id/d",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -55146,7 +55146,7 @@
             "templatecompartment_ref": "~/compartments/id/r",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -55190,7 +55190,7 @@
             "templatecompartment_ref": "~/compartments/id/x",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -55677,7 +55677,7 @@
                 }
             ],
             "templatecomplex_refs": [
-                "~/complexes/id/PS_complex_5831c7"
+                "~/complexes/id/PS_complex_69ea3e"
             ]
         },
         {
@@ -55713,7 +55713,7 @@
                 }
             ],
             "templatecomplex_refs": [
-                "~/complexes/id/PS_complex_5831c7"
+                "~/complexes/id/PS_complex_69ea3e"
             ]
         },
         {
@@ -55749,7 +55749,7 @@
                 }
             ],
             "templatecomplex_refs": [
-                "~/complexes/id/PS_complex_5831c7"
+                "~/complexes/id/PS_complex_69ea3e"
             ]
         },
         {
@@ -55785,7 +55785,7 @@
                 }
             ],
             "templatecomplex_refs": [
-                "~/complexes/id/PS_complex_5831c7"
+                "~/complexes/id/PS_complex_69ea3e"
             ]
         },
         {
@@ -57622,7 +57622,7 @@
             "templatecompartment_ref": "~/compartments/id/d",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -57666,7 +57666,7 @@
             "templatecompartment_ref": "~/compartments/id/r",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -57710,7 +57710,7 @@
             "templatecompartment_ref": "~/compartments/id/x",
             "reaction_ref": "48/1/5/reactions/id/rxn14003",
             "type": "universal",
-            "direction": ">",
+            "direction": "=",
             "GapfillDirection": "=",
             "maxforflux": 0.0,
             "maxrevflux": 0.0,
@@ -58473,7 +58473,7 @@
                 }
             ],
             "templatecomplex_refs": [
-                "~/complexes/id/PS_complex_ed48c3"
+                "~/complexes/id/PS_complex_12c851"
             ]
         },
         {
@@ -66960,14 +66960,14 @@
             ]
         },
         {
-            "id": "PS_complex_1374b1",
+            "id": "PS_complex_12c851",
             "name": "",
             "reference": "",
             "source": "PlantSEED",
             "confidence": 1.0,
             "complexroles": [
                 {
-                    "templaterole_ref": "~/roles/id/PS_role_cb78cd",
+                    "templaterole_ref": "~/roles/id/PS_role_c902af",
                     "optional_role": 0,
                     "triggering": 1
                 }
@@ -67674,6 +67674,20 @@
             "complexroles": [
                 {
                     "templaterole_ref": "~/roles/id/PS_role_28c1a1",
+                    "optional_role": 0,
+                    "triggering": 1
+                }
+            ]
+        },
+        {
+            "id": "PS_complex_2a49f5",
+            "name": "",
+            "reference": "",
+            "source": "PlantSEED",
+            "confidence": 1.0,
+            "complexroles": [
+                {
+                    "templaterole_ref": "~/roles/id/PS_role_8975d1",
                     "optional_role": 0,
                     "triggering": 1
                 }
@@ -68873,6 +68887,20 @@
             ]
         },
         {
+            "id": "PS_complex_3ee0b3",
+            "name": "",
+            "reference": "",
+            "source": "PlantSEED",
+            "confidence": 1.0,
+            "complexroles": [
+                {
+                    "templaterole_ref": "~/roles/id/PS_role_cb78cd",
+                    "optional_role": 0,
+                    "triggering": 1
+                }
+            ]
+        },
+        {
             "id": "PS_complex_3f2638",
             "name": "",
             "reference": "",
@@ -69728,20 +69756,6 @@
             ]
         },
         {
-            "id": "PS_complex_5831c7",
-            "name": "",
-            "reference": "",
-            "source": "PlantSEED",
-            "confidence": 1.0,
-            "complexroles": [
-                {
-                    "templaterole_ref": "~/roles/id/PS_role_726ec8",
-                    "optional_role": 0,
-                    "triggering": 1
-                }
-            ]
-        },
-        {
             "id": "PS_complex_583fda",
             "name": "",
             "reference": "",
@@ -70344,6 +70358,20 @@
             ]
         },
         {
+            "id": "PS_complex_660e96",
+            "name": "",
+            "reference": "",
+            "source": "PlantSEED",
+            "confidence": 1.0,
+            "complexroles": [
+                {
+                    "templaterole_ref": "~/roles/id/PS_role_2b7cf0",
+                    "optional_role": 0,
+                    "triggering": 1
+                }
+            ]
+        },
+        {
             "id": "PS_complex_66310b",
             "name": "",
             "reference": "",
@@ -70514,6 +70542,20 @@
             "complexroles": [
                 {
                     "templaterole_ref": "~/roles/id/PS_role_d0acaa",
+                    "optional_role": 0,
+                    "triggering": 1
+                }
+            ]
+        },
+        {
+            "id": "PS_complex_69ea3e",
+            "name": "",
+            "reference": "",
+            "source": "PlantSEED",
+            "confidence": 1.0,
+            "complexroles": [
+                {
+                    "templaterole_ref": "~/roles/id/PS_role_726ec8",
                     "optional_role": 0,
                     "triggering": 1
                 }
@@ -71314,20 +71356,6 @@
             "complexroles": [
                 {
                     "templaterole_ref": "~/roles/id/PS_role_7a5f1b",
-                    "optional_role": 0,
-                    "triggering": 1
-                }
-            ]
-        },
-        {
-            "id": "PS_complex_82bdcd",
-            "name": "",
-            "reference": "",
-            "source": "PlantSEED",
-            "confidence": 1.0,
-            "complexroles": [
-                {
-                    "templaterole_ref": "~/roles/id/PS_role_8975d1",
                     "optional_role": 0,
                     "triggering": 1
                 }
@@ -73338,6 +73366,14 @@
             ]
         },
         {
+            "id": "PS_complex_c1a4a3",
+            "name": "",
+            "reference": "",
+            "source": "PlantSEED",
+            "confidence": 1.0,
+            "complexroles": []
+        },
+        {
             "id": "PS_complex_c2bdc1",
             "name": "",
             "reference": "",
@@ -74733,20 +74769,6 @@
             ]
         },
         {
-            "id": "PS_complex_ed48c3",
-            "name": "",
-            "reference": "",
-            "source": "PlantSEED",
-            "confidence": 1.0,
-            "complexroles": [
-                {
-                    "templaterole_ref": "~/roles/id/PS_role_c902af",
-                    "optional_role": 0,
-                    "triggering": 1
-                }
-            ]
-        },
-        {
             "id": "PS_complex_ee017c",
             "name": "",
             "reference": "",
@@ -75077,20 +75099,6 @@
             "complexroles": [
                 {
                     "templaterole_ref": "~/roles/id/PS_role_373c38",
-                    "optional_role": 0,
-                    "triggering": 1
-                }
-            ]
-        },
-        {
-            "id": "PS_complex_f80bf6",
-            "name": "",
-            "reference": "",
-            "source": "PlantSEED",
-            "confidence": 1.0,
-            "complexroles": [
-                {
-                    "templaterole_ref": "~/roles/id/PS_role_2b7cf0",
                     "optional_role": 0,
                     "triggering": 1
                 }

--- a/Scripts/PlantSEED_v3/Template/Reaction_Complex_Assignments.txt
+++ b/Scripts/PlantSEED_v3/Template/Reaction_Complex_Assignments.txt
@@ -51,7 +51,7 @@ rxn29919_d	PS_complex_1072dc	PS_role_0bc038	Transaldolase (EC 2.2.1.2)	Athaliana
 rxn05034_m	PS_complex_10b6b9	PS_role_11bf05	4-hydroxybenzoate polyprenyltransferase (EC 2.5.1.39)	Athaliana_TAIR10||AT4G23660
 rxn15116_c|rxn01334_c|rxn15116_d|rxn01334_d	PS_complex_1141a5	PS_role_78470a	Fructose-bisphosphate aldolase class I (EC 4.1.2.13)	Athaliana_TAIR10||AT2G01140|Athaliana_TAIR10||AT2G21330|Athaliana_TAIR10||AT2G36460|Athaliana_TAIR10||AT3G52930|Athaliana_TAIR10||AT4G26520|Athaliana_TAIR10||AT4G26530|Athaliana_TAIR10||AT4G38970|Athaliana_TAIR10||AT5G03690
 rxn01653_m	PS_complex_11b795	PS_role_8945da	5-formyltetrahydrofolate cyclo-ligase (EC 6.3.3.2)	Athaliana_TAIR10||AT5G13050
-rxn24582_c|rxn14068_c|rxn12019_c	PS_complex_1374b1	PS_role_cb78cd	Alkylthiohydroximate C-S lyase (EC 4.4.1.13)	Athaliana_TAIR10||AT2G20610
+rxn41751_c	PS_complex_12c851	PS_role_c902af	Aliphatic glucosinolate S-oxygenase (EC 1.14.13.237)	Athaliana_TAIR10||AT1G12140|Athaliana_TAIR10||AT1G62540|Athaliana_TAIR10||AT1G62560|Athaliana_TAIR10||AT1G62570|Athaliana_TAIR10||AT1G65860
 rxn00366_c|rxn01514_c|rxn00408_c|rxn00120_c|rxn00116_c|rxn01511_c|rxn00366_g|rxn01514_g|rxn00408_g|rxn00120_g|rxn00116_g|rxn01511_g	PS_complex_1397e0	PS_role_fcbd92	Apyrase, ATP-diphosphatase (EC 3.6.1.5)	Athaliana_TAIR10||AT3G04080|Athaliana_TAIR10||AT5G18280
 rxn27360_m|rxn27360_d|rxn27360_x	PS_complex_144aa0	PS_role_8dee88	Phosphoenolpyruvate transport	
 rxn01362_c	PS_complex_14f580	PS_role_d7206b	Orotate phosphoribosyltransferase (EC 2.4.2.10)	Athaliana_TAIR10||AT3G54470
@@ -105,6 +105,7 @@ rxn01426_c	PS_complex_286d26	PS_role_d9aeb8	Caffeoyl-CoA O-methyltransferase (EC
 rxn03147_d	PS_complex_294878	PS_role_3d8cf2	Phosphoribosylaminoimidazole-succinocarboxamide synthase (EC 6.3.2.6)	Athaliana_TAIR10||AT3G21110
 rxn09218_m|rxn09218_d|rxn09218_x	PS_complex_298f6c	PS_role_f64d06	Pyruvate transport	
 rxn46178_d	PS_complex_2a2952	PS_role_28c1a1	Taxane 13-alpha-hydroxylase (EC 1.14.14.106)	Uniprot||Q8W4T9
+rxn21796_c|rxn21798_c|rxn21800_c|rxn21802_c|rxn21804_c|rxn21806_c	PS_complex_2a49f5	PS_role_8975d1	(Methylsulfanyl)alkanaldoxime N-monooxygenase (EC 1.14.14.43)	Athaliana_TAIR10||AT4G13770
 rxn01513_m|rxn01513_c	PS_complex_2a4fd4	PS_role_579dbd	Thymidylate kinase (EC 2.7.4.9)	Athaliana_TAIR10||AT5G59440
 rxn00523_c	PS_complex_2b18f8	PS_role_0537a9	tyrosine N-monooxygenase (EC 1.14.14.36)	Sbicolor_v3.1.1||Sobic.001G012300|Uniprot||Q43135
 rxn03173_c	PS_complex_2b3da6	PS_role_e185b2	Dihydroneopterin triphosphate diphosphatase (EC 3.6.1.n4)	Athaliana_TAIR10||AT1G68760
@@ -232,6 +233,7 @@ rxn00533_d|rxn00533_c	PS_complex_3e0e0e	PS_role_d7cbc8	Biotin carboxyl carrier p
 rxn00533_d|rxn00533_c	PS_complex_3e0e0e	PS_role_4c1143	Biotin carboxylase of acetyl-CoA carboxylase (EC 6.3.4.14)	Athaliana_TAIR10||AT5G35360
 rxn08868_m|rxn08868_d|rxn08868_x	PS_complex_3e44ea	PS_role_70154b	Malate transport	
 rxn08134_m|rxn08134_d	PS_complex_3e7d0d	PS_role_0b912c	AMP transport	
+rxn12019_c|rxn14068_c|rxn24582_c	PS_complex_3ee0b3	PS_role_cb78cd	Alkylthiohydroximate C-S lyase (EC 4.4.1.13)	Athaliana_TAIR10||AT2G20610
 rxn39254_m	PS_complex_3f2638	PS_role_985a1c	Ubiquinone-9 transport	
 rxn00134_c	PS_complex_3f52ab	PS_role_8c7825	Adenosine kinase (EC 2.7.1.20)	Athaliana_TAIR10||AT3G09820|Athaliana_TAIR10||AT5G03300
 rxn22116_m	PS_complex_40133f	PS_role_fa94e4	3,4-dihydroxy-5-polyprenylbenzoate methyltransferase (EC 2.1.1.114)	Athaliana_TAIR10||AT2G30920
@@ -297,7 +299,6 @@ rxn00779_c	PS_complex_5689d2	PS_role_7bb520	Non-phosphorylating glyceraldehyde-3
 rxn01069_d	PS_complex_57a71b	PS_role_ce5990	Threonine synthase (EC 4.2.3.1)	Athaliana_TAIR10||AT1G72810|Athaliana_TAIR10||AT4G29840
 rxn02998_c	PS_complex_57d25b	PS_role_9f1313	4-hydroxyphenylacetaldehyde oxime monooxygenase (EC 1.14.14.37)	Sbicolor_v3.1.1||Sobic.001G012200|Uniprot||Q48958
 rxn00506_c|rxn00506_m|rxn00506_d	PS_complex_57e8aa	PS_role_3ed002	Aldehyde dehydrogenase (EC 1.2.1.3)	Athaliana_TAIR10||AT1G23800|Athaliana_TAIR10||AT1G44170|Athaliana_TAIR10||AT1G54100|Athaliana_TAIR10||AT3G48000|Athaliana_TAIR10||AT4G34240|Athaliana_TAIR10||AT4G36250
-rxn27056_c|rxn14133_c|rxn02300_c|rxn14362_c|rxn27057_c|rxn11704_c|rxn27059_c|rxn27058_c	PS_complex_5831c7	PS_role_726ec8	Aliphatic desulfoglucosinolate sulfotransferase (EC 2.8.2.38)	Athaliana_TAIR10||AT1G18590|Athaliana_TAIR10||AT1G74090
 rxn19824_c	PS_complex_583fda	PS_role_2f91cd	Glutamyl-tRNA synthetase (EC 6.1.1.17)	Athaliana_TAIR10||AT5G26710
 rxn00333_x|rxn00333_d	PS_complex_5859c6	PS_role_437b19	Glycolate oxidase (EC 1.1.3.15)	Athaliana_TAIR10||AT3G14130|Athaliana_TAIR10||AT3G14150|Athaliana_TAIR10||AT3G14415|Athaliana_TAIR10||AT3G14420|Athaliana_TAIR10||AT4G18360
 rxn08544_m|rxn08544_d|rxn08544_x	PS_complex_587419	PS_role_1a2ec2	Fumarate transport	
@@ -341,6 +342,7 @@ rxn09193_m|rxn09193_d|rxn09193_x	PS_complex_63af19	PS_role_66525b	Proline transp
 rxn21810_c|rxn21809_c|rxn21816_c|rxn21813_c|rxn21814_c|rxn21815_c|rxn21811_c|rxn21812_c	PS_complex_63c3f0	PS_role_9af9d5	Glutathione S-transferase	Athaliana_TAIR10||AT1G27130|Athaliana_TAIR10||AT1G78370|Athaliana_TAIR10||AT2G30860|Athaliana_TAIR10||AT2G30870|Athaliana_TAIR10||AT3G03190
 rxn34467_v|rxn34467_d|rxn34467_m	PS_complex_6436d9	PS_role_3e578e	5-Methylenyltetrahydrofolate transport	Athaliana_TAIR10||AT1G30400|Athaliana_TAIR10||AT2G32040|Athaliana_TAIR10||AT5G66380
 rxn00467_m	PS_complex_64be7d	PS_role_127d6b	Ornithine aminotransferase (EC 2.6.1.13)	Athaliana_TAIR10||AT5G46180
+rxn21817_c|rxn21818_c|rxn21819_c|rxn21820_c|rxn21821_c|rxn21822_c|rxn21823_c|rxn21824_c	PS_complex_660e96	PS_role_2b7cf0	Glucosinolate gamma-glutamyl hydrolase (EC 3.4.19.16)	Athaliana_TAIR10||AT2G23960|Athaliana_TAIR10||AT2G23970|Athaliana_TAIR10||AT4G29210|Athaliana_TAIR10||AT4G30530|Athaliana_TAIR10||AT4G30540|Athaliana_TAIR10||AT4G30550
 rxn02312_m	PS_complex_66310b	PS_role_5a0cac	Adenosylmethionine-8-amino-7-oxononanoate aminotransferase (EC 2.6.1.62)	Athaliana_TAIR10||AT5G57590
 rxn26477_d	PS_complex_66b600	PS_role_22b8b8	1-hydroxy-2-methyl-2-(E)-butenyl 4-diphosphate synthase (EC 1.17.7.1)	Athaliana_TAIR10||AT5G60600
 rxn01019_d	PS_complex_66bb18	PS_role_23fed7	Ornithine carbamoyltransferase (EC 2.1.3.3)	Athaliana_TAIR10||AT1G75330
@@ -353,6 +355,7 @@ rxn00802_d	PS_complex_68b6ca	PS_role_2c0c10	Argininosuccinate lyase (EC 4.3.2.1)
 rxn15069_m|rxn15069_n|rxn15069_c|rxn15069_d	PS_complex_68e94a	PS_role_0278da	Sucrose alpha-glucosidase, alkaline/neutral invertase (EC 3.2.1.26)	Athaliana_TAIR10||AT1G35580|Athaliana_TAIR10||AT1G56560|Athaliana_TAIR10||AT1G72000|Athaliana_TAIR10||AT3G05820|Athaliana_TAIR10||AT3G06500|Athaliana_TAIR10||AT4G09510|Athaliana_TAIR10||AT4G34860|Athaliana_TAIR10||AT5G22510
 rxn01258_d	PS_complex_696a17	PS_role_584002	Isochorismate synthase (EC 5.4.4.2)	Athaliana_TAIR10||AT1G18870|Athaliana_TAIR10||AT1G74710
 rxn24131_c	PS_complex_69713d	PS_role_d0acaa	UDP-glucose:p-aminobenzoate glucosyltransferase	Athaliana_TAIR10||AT1G05560|Athaliana_TAIR10||AT2G43820|Athaliana_TAIR10||AT2G43840
+rxn02300_c|rxn11704_c|rxn14133_c|rxn14362_c|rxn27056_c|rxn27057_c|rxn27058_c|rxn27059_c	PS_complex_69ea3e	PS_role_726ec8	Aliphatic desulfoglucosinolate sulfotransferase (EC 2.8.2.38)	Athaliana_TAIR10||AT1G18590|Athaliana_TAIR10||AT1G74090
 rxn01478_c|rxn04682_c|rxn04681_c	PS_complex_6a0d64	PS_role_6771b2	Phosphoethanolamine N-methyltransferase (EC 2.1.1.103)	Athaliana_TAIR10||AT1G48600|Athaliana_TAIR10||AT1G73600|Athaliana_TAIR10||AT3G18000
 rxn03135_d	PS_complex_6a8077	PS_role_0718b5	Imidazole glycerol phosphate synthase amidotransferase subunit (EC 2.4.2.-)	Athaliana_TAIR10||AT4G26900
 rxn03135_d	PS_complex_6a8077	PS_role_f92d66	Imidazole glycerol phosphate synthase cyclase subunit (EC 4.1.3.-)	Athaliana_TAIR10||AT4G26900
@@ -414,7 +417,6 @@ rxn17731_m	PS_complex_8244c8	PS_role_314a65	Adrenodoxin reductase (EC 1.18.1.6)	
 rxn17731_m	PS_complex_8244c8	PS_role_646a72	Adrenodoxin, mitochondrial ferredoxin	Athaliana_TAIR10||AT4G05450|Athaliana_TAIR10||AT4G21090
 rxn00189_c	PS_complex_828dc0	PS_role_41e45e	Glutaminase (EC 3.5.1.2)	
 rxn26498_d|rxn26498_c	PS_complex_82b40b	PS_role_7a5f1b	Light-dependent protochlorophyllide reductase (EC 1.3.1.33)	Athaliana_TAIR10||AT1G03630|Athaliana_TAIR10||AT4G27440|Athaliana_TAIR10||AT5G54190
-rxn21796_c|rxn21804_c|rxn21802_c|rxn21798_c|rxn21806_c|rxn21800_c	PS_complex_82bdcd	PS_role_8975d1	(Methylsulfanyl)alkanaldoxime N-monooxygenase (EC 1.14.14.43)	Athaliana_TAIR10||AT4G13770
 rxn01300_d	PS_complex_82d17d	PS_role_21308c	Homoserine kinase (EC 2.7.1.39)	Athaliana_TAIR10||AT2G17265
 rxn09188_m	PS_complex_82fb57	PS_role_69514c	Proline dehydrogenase (EC 1.5.5.2)	Athaliana_TAIR10||AT3G30775|Athaliana_TAIR10||AT5G38710|UniProt||P92983|UniProt||Q6NKX1
 rxn03057_c	PS_complex_830033	PS_role_7cd262	Methylthioribose-1-phosphate isomerase (EC 5.3.1.23)	Athaliana_TAIR10||AT2G05830
@@ -690,7 +692,6 @@ rxn38795_m	PS_complex_ebbd5d	PS_role_c8a048	HMDHP transport
 rxn00459_c|rxn00459_n|rxn00459_d	PS_complex_ecfa74	PS_role_c46d10	Enolase (EC 4.2.1.11)	Athaliana_TAIR10||AT1G74030|Athaliana_TAIR10||AT2G29560|Athaliana_TAIR10||AT2G36530
 rxn02474_d	PS_complex_ed268c	PS_role_49d7f6	5-amino-6-(5-phosphoribosylamino)uracil reductase (EC 1.1.1.193)	Athaliana_TAIR10||AT3G47390|Athaliana_TAIR10||AT4G20960
 rxn09005_c|rxn09005_m|rxn09005_d	PS_complex_ed3575	PS_role_f0c5ba	Nitrate transport	
-rxn41751_c	PS_complex_ed48c3	PS_role_c902af	Aliphatic glucosinolate S-oxygenase (EC 1.14.13.237)	Athaliana_TAIR10||AT1G12140|Athaliana_TAIR10||AT1G62540|Athaliana_TAIR10||AT1G62560|Athaliana_TAIR10||AT1G62570|Athaliana_TAIR10||AT1G65860
 rxn02959_d|rxn02959_c	PS_complex_ee017c	PS_role_909ab6	Mg-protoporphyrin O-methyltransferase (EC 2.1.1.11)	Athaliana_TAIR10||AT4G25080
 rxn15229_c	PS_complex_ee1b2a	PS_role_44a05e	Purine nucleosidase (EC 3.2.2.1)	
 rxn00571_c	PS_complex_ee91be	PS_role_da16ce	Nitrate reductase [NADH] (EC 1.7.1.1)	Athaliana_TAIR10||AT1G37130|Athaliana_TAIR10||AT1G77760
@@ -715,7 +716,6 @@ rxn00830_c|rxn00830_d|rxn00830_m	PS_complex_f5c311	PS_role_9c323b	Isopentenyl-di
 rxn01670_c|rxn00363_c|rxn00708_c	PS_complex_f61d02	PS_role_25455b	5'-nucleotidase (EC 3.1.3.5)	Athaliana_TAIR10||AT1G72880|Athaliana_TAIR10||AT2G38680|Athaliana_TAIR10||AT4G14930
 rxn00437_c	PS_complex_f6ebce	PS_role_7b2dc9	Thiamine-triphosphatase (ThTP) synthase (EC 2.7.4.15)	
 rxn16291_r|rxn16300_r|rxn16289_r|rxn20987_r|rxn16291_c|rxn16300_c|rxn16289_c|rxn20987_c	PS_complex_f7651b	PS_role_373c38	Fatty acid omega-hydroxylase (EC 1.14.13.-)	Athaliana_TAIR10||AT1G01600|Athaliana_TAIR10||AT2G27690|Athaliana_TAIR10||AT2G45970|Athaliana_TAIR10||AT4G00360
-rxn21822_c|rxn21819_c|rxn21818_c|rxn21821_c|rxn21817_c|rxn21824_c|rxn21820_c|rxn21823_c	PS_complex_f80bf6	PS_role_2b7cf0	Glucosinolate gamma-glutamyl hydrolase (EC 3.4.19.16)	Athaliana_TAIR10||AT2G23960|Athaliana_TAIR10||AT2G23970|Athaliana_TAIR10||AT4G29210|Athaliana_TAIR10||AT4G30530|Athaliana_TAIR10||AT4G30540|Athaliana_TAIR10||AT4G30550
 rxn02476_d	PS_complex_f88088	PS_role_f66dc6	5-Enolpyruvylshikimate-3-phosphate synthase (EC 2.5.1.19)	Athaliana_TAIR10||AT1G48860|Athaliana_TAIR10||AT2G45300
 rxn08170_m|rxn08170_d|rxn08170_x	PS_complex_f8c73e	PS_role_6b05a6	Aspartate transport	
 rxn00533_c|rxn00533_d	PS_complex_f8eb4e	PS_role_ef4598	Acetyl-coenzyme A carboxyl transferase domain of homomeric ACCase (EC 6.4.1.2)	Athaliana_TAIR10||AT1G36160|Athaliana_TAIR10||AT1G36180

--- a/Scripts/PlantSEED_v3/Template/Transport_Compartment_Rules.yaml
+++ b/Scripts/PlantSEED_v3/Template/Transport_Compartment_Rules.yaml
@@ -1,0 +1,49 @@
+# Transport compartment translation rules
+# =========================================
+#
+# Roles in PlantSEED_Roles.json can have a `localization` keyed by either:
+#   - a single-letter compartment code (a reaction that happens entirely in
+#     one compartment), e.g. `c`, `d`, `m`, `x`, `v`
+#   - a two-letter code (a transporter that spans two compartments), e.g.
+#     `cd` (cytosol <-> plastid), `mj` (mitochondrial matrix <-> intermembrane)
+#
+# The metabolic model itself only uses single-letter compartments. So when
+# the complex generator (Prepare_PlantSEED_KBase.py) and the template
+# generator (Generate_Core_ModelTemplate.py / Add_ModelTemplate_Gapfilling.py)
+# project a transporter reaction into the model, the 2-letter code must be
+# collapsed to a single letter. The rules below define that collapse.
+#
+# How the rules are applied
+# -------------------------
+# - One-letter localization codes pass through unchanged.
+# - For a two-letter code, the rules below apply IN ORDER. Each rule that
+#   matches overrides the previous result. The first letter of the code is
+#   the default if no rule matches.
+# - `if_contains: X` matches when the single letter X appears anywhere in
+#   the two-letter code.
+# - `result: other` picks the letter in the pair that is NOT X.
+# - `result: <single-letter>` picks that letter exactly.
+#
+# Editing this file
+# -----------------
+# - Edits propagate to any script that loads this file. As of now that's
+#   only Prepare_PlantSEED_KBase.py. Generate_Core_ModelTemplate.py and
+#   Add_ModelTemplate_Gapfilling.py both still carry hard-coded copies of
+#   these rules (the gapfilling script is incomplete - missing the `y`
+#   exception) and should be migrated here in a follow-up.
+# - Adding a new exception is just a new entry in the `rules:` list. Put
+#   the most specific exceptions LAST so they override the general rules.
+
+rules:
+  - if_contains: c
+    result: other
+    note: "Non-cytosolic wins by default - cytosol/organelle transporters live in the organelle."
+  - if_contains: e
+    result: other
+    note: "Extracellular transporters resolve to the non-extracellular side."
+  - if_contains: j
+    result: j
+    note: "Mitochondrial intermembrane space (j) wins over the mitochondrial matrix (m)."
+  - if_contains: y
+    result: y
+    note: "Thylakoid lumen (y) wins over plastid stroma (d)."


### PR DESCRIPTION
## Summary

Consolidates two chunks of pending work into one PR: (1) refactoring `Prepare_PlantSEED_KBase.py` onto the shared `plantseed_curation` library, and (2) landing the glucosinolate complex migration that had been sitting on the `complex_updates_260601` branch.

## Commits

- **`d6cacb0`** — Refactor `Prepare_PlantSEED_KBase.py` onto `plantseed_curation` library
- **`83a4899`** — Validate role `subcomplex_of` pointers
- **`908766e`** — Add `Transport_Compartment_Rules.yaml` + `PlantSEED_Complexes_Schema.yaml`; fix `ce`/`de` translation
- **`283de73`** — Apply glucosinolate complex migration to `PlantSEED_Complexes.json`
- **`0a83b90`** — Regenerate template artifacts for glucosinolate complex migration

## What changes

### Script + library refactor (`d6cacb0`, `83a4899`)

`Prepare_PlantSEED_KBase.py` shrinks from 179 lines of inline JSON I/O + hash construction + compartment bookkeeping + warning-via-print to ~100 lines of pure orchestration. Every reusable piece moves into `plantseed_curation`:

- New in `paths.py`: `COMPLEXES_FILE` (with `PLANTSEED_COMPLEXES_FILE` env override).
- New in `actions.py`:
  - `complex_kbase_id(enzyme, roles, rxn_cpts)` — pure `PS_complex_<sha256[:6]>` hash.
  - `enzyme_rxn_cpts(entry)` — canonical rxn_cpt extraction.
  - `assign_complex_kbase_id(entry, existing_ids, issues)` — mirror of `assign_kbase_id` for complexes.
  - `enzyme_index_from_complexes(complexes_list, issues)` — build lookup + warn on duplicate ids.
  - `derive_new_complexes(roles_list, enzyme_index, existing_ids, issues)` — **replaces the crashing `New enzyme!` branch** in the old script (list-vs-dict init, wrong `PS_` prefix, missing enzyme key). Groups by `abstract_enzyme` with `Spontaneous Reaction||rxn*` disambiguation, maps 2-letter localization keys to their single-letter `cpt_id` with `reagents=lcz` to match hand-authored transport complexes.
  - `validate_subcomplex_pointers(roles_list, complex_ids, issues)` — warns on `subcomplex_of` values that don't resolve. Called AFTER `derive_new_complexes` so a role pointing at a freshly-minted parent doesn't false-positive.

Per `add5726`'s author note, `subcomplex_of` does NOT influence complex-id generation — I verified by stripping the 2 carve-out complexes and re-running `derive_new_complexes`: they get correctly re-minted via their `abstract_enzyme`, and all 3 tagged roles' pointers still resolve.

### Yaml files + transport rule fix (`908766e`)

- Brings `Scripts/PlantSEED_v3/Curation/PlantSEED_Complexes_Schema.yaml` and `Scripts/PlantSEED_v3/Template/Transport_Compartment_Rules.yaml` over from `complex_updates_260601` unchanged.
- The Complexes schema is not yet wired into validation — ships now so future complex-side validation helpers have a canonical source.
- Fixes a **latent bug** in `_lcz_to_cpt_id`: was `lcz[-1]` (naive last-letter), which happens to match the yaml rules for 6 of 8 real-world 2-letter codes but is **wrong** for `ce` (should → `c`, was → `e`; 14 role occurrences) and `de` (should → `d`, was → `e`; 1 occurrence). Bug was latent because those 15 roles all already have complex entries — but the next curator with a `ce`/`de` role would have hit it. Now uses an in-order rule engine mirroring the yaml verbatim. A sync test fails if the yaml and the hardcoded `_TRANSPORT_RULES` tuple drift.

### Migration data (`283de73`)

Cherry-picked from `161e7c6`. Dev's `PlantSEED_Complexes.json` had 5 orphaned complexes whose `enzyme` fields no longer matched any role's `abstract_enzyme` (the roles were renamed in late 2024 but the propagator crashed before writing).

Dropped (5):
- `PS_complex_5831c7` Desulfoglucosinolate sulfotransferase
- `PS_complex_ed48c3` Flavin-containing glucosinolate S-oxygenase
- `PS_complex_f80bf6` Gamma-glutamyl peptidase in glucosinolates biosynthesis
- `PS_complex_82bdcd` Oxime metabolizining monooxygenase in aliphatic glucosinolates biosynthesis
- `PS_complex_1374b1` S-alkyl-thiohydroximate lyase

Added (6):
- `PS_complex_69ea3e` Aliphatic desulfoglucosinolate sulfotransferase (8 rxn)
- `PS_complex_12c851` Aliphatic glucosinolate S-oxygenase (1 rxn)
- `PS_complex_3ee0b3` Alkylthiohydroximate C-S lyase (3 rxn)
- `PS_complex_660e96` Glucosinolate gamma-glutamyl hydrolase (8 rxn)
- `PS_complex_2a49f5` (Methylsulfanyl)alkanaldoxime N-monooxygenase (6 rxn)
- `PS_complex_c1a4a3` Aromatic desulfoglucosinolate sulfotransferase (0 rxn — pending curation placeholder)

**Downstream KBase consumers tracking any of the 5 dropped `PS_complex_*` ids will need to remap.**

### Template regeneration (`0a83b90`)

Ran `Scripts/PlantSEED_v3/Template/Generate_Core_ModelTemplate.py` against the migrated complexes. Two files refresh:

- `Reaction_Complex_Assignments.txt`: 5 `PS_complex_*` id substitutions, verified programmatically — every added/removed id is in the migration set.
- `PlantSEED_Neutral_Template.json`: same 5 id substitutions propagated through `templatecomplex_refs` and `complexes`/`complexroles` arrays.

Generator log confirmed:
- Subcomplex_of absorption still works: `PS_complex_5bd6c2` (Aminomethyltransferase) AND-extended into `PS_complex_32252b` (GCS parent); `PS_complex_743fd8` (Cytochrome b559) AND-extended into `PS_complex_385743` (PS II parent).
- Aromatic desulfoglucosinolate sulfotransferase excluded from `templatecomplex_refs` — expected, no reactions on its role.

## Verification

- **Tests: 129 passing** (was 90 on dev, +39 new tests covering all the new library helpers, transport rule cases, yaml-sync guard, and subcomplex_of pointer validation).
- Running the refactored `Prepare_PlantSEED_KBase.py` after this PR lands is a **complete no-op** — no new kbase_ids minted, no files written.
- Zero overlap with dev's `be55d39` (`Curators/samseaver/template_reaction_curation_260602/*`) — different files, different concerns (be55d39 captures reaction chemistry as documentation TSVs; this PR covers complex-name migration + library refactor). The resume-memory concern about redundancy applied to a sketched follow-up that isn't in this PR.

## Notes for future phases (not in this PR)

- The complex-schema validation loop (`ensure_schema_defaults`, `validate_dependencies` for complexes) that his `Prepare_PlantSEED_KBase.py` rewrite in `161e7c6` also included is **not** in this PR. Follow-up phase can plumb `PlantSEED_Complexes_Schema.yaml` into those helpers.
- His `carry_over_biochem` and output-ordering preservation are similarly deferred to a follow-up.
- `Generate_Core_ModelTemplate.py` and `Add_ModelTemplate_Gapfilling.py` still carry hard-coded copies of the transport rules; migrating them to load `Transport_Compartment_Rules.yaml` is a follow-up.

Related resume memory: `~/.claude/projects/-scratch-seaver-Claude-Projects-PlantSEED-Refactor/memory/complex_updates_branch_decision.md`. The 3-step plan there is superseded by these 5 commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
