### PR TITLE
Backfill KBase Perl annotators' Template_Compartment_Mapping

### DIFF
--- a/Scripts/PlantSEED_v3/KBase/Annotate_Arabidopsis_Genome_in_KBase.pl
+++ b/Scripts/PlantSEED_v3/KBase/Annotate_Arabidopsis_Genome_in_KBase.pl
@@ -13,7 +13,10 @@ my %Template_Compartment_Mapping=('c' => 'cytosol', 'g' => 'golgi', 'w' => 'cell
                                   'd' => 'plastid', 'cd' => 'plastid',
                                   'm' => 'mitochondria','cm' => 'mitochondria',
                                   'mj' => 'mitointer',
-                                  'x' => 'peroxisome');
+                                  'x' => 'peroxisome', 'cx' => 'peroxisome',
+                                  'e' => 'extracellular', 'ce' => 'extracellular',
+                                  'de' => 'plastid',
+                                  'dy' => 'thylakoid', 'y' => 'thylakoid');
 
 #KBase Environment
 my $Workspace_URL = "https://appdev.kbase.us/services/ws";

--- a/Scripts/PlantSEED_v3/KBase/Annotate_Single_Genome_in_KBase.pl
+++ b/Scripts/PlantSEED_v3/KBase/Annotate_Single_Genome_in_KBase.pl
@@ -17,7 +17,10 @@ my %Template_Compartment_Mapping=('c' => 'cytosol', 'g' => 'golgi', 'w' => 'cell
                                   'd' => 'plastid', 'cd' => 'plastid',
                                   'm' => 'mitochondria','cm' => 'mitochondria',
                                   'mj' => 'mitointer',
-                                  'x' => 'peroxisome');
+                                  'x' => 'peroxisome', 'cx' => 'peroxisome',
+                                  'e' => 'extracellular', 'ce' => 'extracellular',
+                                  'de' => 'plastid',
+                                  'dy' => 'thylakoid', 'y' => 'thylakoid');
 
 # Here, these values are rather arbitrary, but are based on examining
 # how many of the metabolic functions are propagated between Arabidopsis


### PR DESCRIPTION
The compartment map in both Annotate_Single_Genome_in_KBase.pl and Annotate_Arabidopsis_Genome_in_KBase.pl was missing six localization keys that actually appear in current dev's PlantSEED_Roles.json:

  cx (44 role occurrences) — cytosol <-> peroxisome transport   -> peroxisome
  ce (14 role occurrences) — cytosol <-> extracellular transport -> extracellular
  e  ( 2 role occurrences) — extracellular                       -> extracellular
  de ( 1 role occurrence)  — plastid  <-> extracellular          -> plastid
  dy (43 role occurrences) — plastid  <-> thylakoid lumen        -> thylakoid
  y  ( 0 today, added defensively)                               -> thylakoid

Perl fails hard on missing hash keys under `use strict; use warnings;` (the map raises "Use of uninitialized value in join"), so any role with one of these keys silently loses its compartment tag in the emitted function string — defaulting to cytosol at reconstruction time.

Choice of target compartment matches Scripts/PlantSEED_v3/Template/Transport_Compartment_Rules.yaml:
  if_contains: e -> other  (non-extracellular wins)
  if_contains: y -> y      (thylakoid lumen wins over plastid stroma)
  if_contains: c -> other  (non-cytosolic side wins for transport)

Same fix landed in Aug 2026 against kbaseapps/kb_orthofinder and kbaseapps/plant_fba (branch: add-dy-compartment-260806) on the Python side; this commit brings the Perl scripts in line.