### PR TITLE
Plantseed annotation scaffold 260806

### DIFF
--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/__init__.py
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/__init__.py
@@ -1,0 +1,22 @@
+"""plantseed_annotation — shared library for the plant genome annotator.
+
+Mirrors the layout of the plantseed_curation package next door:
+  - paths.py       — PLANTSEED_ANNOT_* env-var overrides for every file path
+  - config.py      — tier presets (kbase / poplar / local) that pin CPU/RAM/refdata
+  - reference.py   — locate + verify the versioned refdata bundle
+  - refbuild/      — offline scripts that (re)build a bundle from PlantSEED_Roles.json
+  - algorithms/    — pluggable annotation algorithms
+  - dispatch.py    — pick algorithm(s) for a run based on tier + role phylum
+  - genome_io.py   — KBase Genome  <->  standalone JSON adapters
+  - emit.py        — write both `role # compartment` strings AND PS_role_* ids
+  - cli.py         — `plantseed-annotate --genome ... --tier {kbase,poplar,local}`
+
+Consumers (KBase SDK App, poplar celery worker, local Docker) all pip-install
+this package and go through the public API re-exported below; no algorithm
+code is duplicated in any wrapper.
+
+Approved plan: ~/.claude/plans/ok-entirely-new-and-functional-tulip.md
+"""
+
+# Public API surface — filled in as each phase lands.
+__all__ = []

--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/__init__.py
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/__init__.py
@@ -1,22 +1,59 @@
 """plantseed_annotation — shared library for the plant genome annotator.
 
-Mirrors the layout of the plantseed_curation package next door:
-  - paths.py       — PLANTSEED_ANNOT_* env-var overrides for every file path
-  - config.py      — tier presets (kbase / poplar / local) that pin CPU/RAM/refdata
-  - reference.py   — locate + verify the versioned refdata bundle
-  - refbuild/      — offline scripts that (re)build a bundle from PlantSEED_Roles.json
-  - algorithms/    — pluggable annotation algorithms
-  - dispatch.py    — pick algorithm(s) for a run based on tier + role phylum
-  - genome_io.py   — KBase Genome  <->  standalone JSON adapters
-  - emit.py        — write both `role # compartment` strings AND PS_role_* ids
-  - cli.py         — `plantseed-annotate --genome ... --tier {kbase,poplar,local}`
+Public API (Phase 1a): the standalone annotator that consumes a user's
+OrthoFinder results directory + PlantSEED_Roles.json and produces an
+annotated genome JSON in the shape reconstruct_app_impl.py consumes.
 
-Consumers (KBase SDK App, poplar celery worker, local Docker) all pip-install
-this package and go through the public API re-exported below; no algorithm
-code is duplicated in any wrapper.
-
-Approved plan: ~/.claude/plans/ok-entirely-new-and-functional-tulip.md
+    from plantseed_annotation import (
+        build_curated_features, annotate_species, write_annotated_genome,
+    )
 """
 
-# Public API surface — filled in as each phase lands.
-__all__ = []
+from . import config, genome_io, paths
+from .algorithms import orthofinder_io, propagate, psi, psi_refined
+
+from .algorithms.propagate import (
+    COMPARTMENT_MAPPING,
+    build_curated_features,
+    curated_features_by_source_species,
+    function_for_ortholog,
+)
+from .algorithms.psi_refined import (
+    annotate_query_gene,
+    annotate_species,
+)
+from .algorithms.psi import (
+    compute_psi_for_msa,
+    ensure_psi_cache,
+    load_psi_for_ogs,
+)
+from .algorithms.orthofinder_io import (
+    load_orthogroups,
+    load_orthologues,
+    orthologues_path,
+    read_msa,
+    species_from_orthogroups,
+    species_gene_to_og_index,
+)
+from .genome_io import (
+    build_annotated_genome,
+    write_annotated_genome,
+)
+
+__all__ = [
+    # subpackages
+    "config", "genome_io", "paths",
+    "orthofinder_io", "propagate", "psi", "psi_refined",
+    # propagate
+    "COMPARTMENT_MAPPING", "build_curated_features",
+    "curated_features_by_source_species", "function_for_ortholog",
+    # psi_refined
+    "annotate_query_gene", "annotate_species",
+    # psi
+    "compute_psi_for_msa", "ensure_psi_cache", "load_psi_for_ogs",
+    # orthofinder_io
+    "load_orthogroups", "load_orthologues", "orthologues_path",
+    "read_msa", "species_from_orthogroups", "species_gene_to_og_index",
+    # genome_io
+    "build_annotated_genome", "write_annotated_genome",
+]

--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/algorithms/__init__.py
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/algorithms/__init__.py
@@ -1,0 +1,12 @@
+"""Pluggable annotation algorithms.
+
+  place_query  — put a query genome's proteins into the enriched OrthoFinder
+                 families (default: OrthoFinder -b insert mode against the
+                 bundle; possible follow-up: DIAMOND-first placement)
+  psi_refined  — port of Identify_Functional_Homologs.py; picks the top curated
+                 ortholog per query using per-species-pair PSI mean + phylum
+                 threshold
+  propagate    — top ortholog -> PlantSEED function/compartment string and
+                 PS_role_* stable id; source-species agnostic
+  kmer         — 8-mer signature match (fast path, ported from ProbModelSEED)
+"""

--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/algorithms/kmer.py
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/algorithms/kmer.py
@@ -1,0 +1,11 @@
+"""8-mer signature match — fast-path annotation, ported from ProbModelSEED's
+lib/Bio/ModelSEED/ProbModelSEED/ProbModelSEEDHelper.pm::annotate_plant_genome_kmers.
+
+Optional follow-up to the primary place_query + psi_refined + propagate
+pipeline. Useful on the KBase tier when the bundle's SHOOT/OrthoFinder
+data would blow the 10 GB refdata cap; the kmer index is tiny and
+comfortably fits in 22 GB / 2 cores.
+
+Kmer length = 8, threshold = 1, tie-break by top count — matches the
+ProbModelSEED implementation.
+"""

--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/algorithms/orthofinder_io.py
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/algorithms/orthofinder_io.py
@@ -1,0 +1,185 @@
+"""Read OrthoFinder result directories.
+
+A standard OrthoFinder-2 results directory has this shape:
+
+    Results_MonAug06/
+      Orthogroups/Orthogroups.tsv             — one row per OG, one col per species
+      Orthologues/                            — pairwise ortholog assignments
+        Orthologues_<A>/                        (nested by species)
+          <A>__v__<B>.tsv                       (one line per OG containing genes from both)
+      MultipleSequenceAlignments/OG*.fa       — per-OG protein MSA (input to PSI)
+      Gene_Trees/OG*_tree.txt                 — per-OG ML gene tree
+
+We only touch the first three at annotation time. Gene trees are used later
+(Phase 1d) by SHOOT-based reference enrichment.
+"""
+
+import itertools
+import os
+
+
+def _strip_species_prefix(gene_id, species):
+    """OF cell entries in this repo carry a redundant '<species>||' prefix
+    (Sam's fasta headers were built that way; see Print_JSON_Genome_to_FASTA.pl).
+    Strip it so callers can compare against curated ids that don't carry the
+    prefix. Genes without the prefix pass through unchanged."""
+    prefix = species + "||"
+    return gene_id[len(prefix):] if gene_id.startswith(prefix) else gene_id
+
+
+def _strip_species_prefix_any(gene_id):
+    """Strip whatever '<anything>||' prefix is present (for MSA headers,
+    where the species varies per row)."""
+    return gene_id.split("||", 1)[1] if "||" in gene_id else gene_id
+
+
+def transcript_to_gene(tid):
+    """Collapse a transcript-level id back to its gene-level id by stripping
+    a trailing '.<digits>' suffix.
+
+        'AT1G01050.1'       -> 'AT1G01050'
+        'Sobic.001G234700.1' -> 'Sobic.001G234700'
+        'Potri.001G067600.1' -> 'Potri.001G067600'
+        'AT1G01050'         -> 'AT1G01050'         (no change)
+        'Sobic.001G234700'  -> 'Sobic.001G234700'  (no change; last segment isn't digits)
+
+    Used to match transcript-level OF ids against gene-level curated ids in
+    PlantSEED_Roles.json."""
+    if "." not in tid:
+        return tid
+    left, right = tid.rsplit(".", 1)
+    return left if right.isdigit() else tid
+
+
+# --- Orthogroups.tsv ---------------------------------------------------------
+def load_orthogroups(orthogroups_tsv):
+    """Parse Orthogroups.tsv → {og_id: {species: [gene_id, ...]}}.
+
+    Cell entries have their redundant '<species>||' prefix stripped so
+    callers can compare directly against curated gene ids.
+    Species with no gene in an OG get an empty list. Splits on ', ' the way
+    OrthoFinder writes multi-gene cells.
+    """
+    ogs = {}
+    with open(orthogroups_tsv) as fh:
+        header = fh.readline().rstrip("\n").split("\t")
+        species = header[1:]
+        for line in fh:
+            row = line.rstrip("\n").split("\t")
+            og_id = row[0]
+            entry = {}
+            for i, spp in enumerate(species):
+                cell = row[i + 1] if i + 1 < len(row) else ""
+                genes = [g for g in cell.split(", ") if g] if cell else []
+                entry[spp] = [_strip_species_prefix(g, spp) for g in genes]
+            ogs[og_id] = entry
+    return ogs, species
+
+
+def og_containing_gene(ogs, species, gene_id):
+    """Return the og_id containing (species, gene_id), or None."""
+    for og_id, entry in ogs.items():
+        if gene_id in entry.get(species, []):
+            return og_id
+    return None
+
+
+def species_gene_to_og_index(ogs):
+    """Build a `{(species, gene_id): og_id}` reverse index for O(1) lookup.
+    Cheaper than repeatedly calling og_containing_gene."""
+    idx = {}
+    for og_id, entry in ogs.items():
+        for spp, genes in entry.items():
+            for gene in genes:
+                idx[(spp, gene)] = og_id
+    return idx
+
+
+# --- Orthologues/<A>__v__<B>.tsv ---------------------------------------------
+def orthologues_path(results_dir, spp_a, spp_b):
+    """Return the path to `Orthologues/Orthologues_<A>/<A>__v__<B>.tsv`, or
+    None if the file doesn't exist."""
+    candidate = os.path.join(
+        results_dir, "Orthologues", f"Orthologues_{spp_a}",
+        f"{spp_a}__v__{spp_b}.tsv",
+    )
+    return candidate if os.path.isfile(candidate) else None
+
+
+def load_orthologues(orthologues_tsv):
+    """Parse an `<A>__v__<B>.tsv` file.
+
+    Each row: og_id \\t genes-in-A (', '-joined) \\t genes-in-B (', '-joined).
+    Species names are taken from the header line (column 1 = species A,
+    column 2 = species B); the '<species>||' prefix is stripped from every
+    gene id at parse time so callers see clean ids.
+
+    Returns two dicts, both keyed by gene id:
+      {a_gene: {'og': og_id, 'orthologs': [b_gene, ...]}}
+      {b_gene: {'og': og_id, 'orthologs': [a_gene, ...]}}
+    """
+    a_to_b = {}
+    b_to_a = {}
+    with open(orthologues_tsv) as fh:
+        header = fh.readline().rstrip("\n").split("\t")
+        spp_a = header[1] if len(header) > 1 else ""
+        spp_b = header[2] if len(header) > 2 else ""
+        for line in fh:
+            row = line.rstrip("\n").split("\t")
+            if len(row) < 3:
+                continue
+            og_id = row[0]
+            a_genes = [_strip_species_prefix(g, spp_a)
+                       for g in row[1].split(", ") if g]
+            b_genes = [_strip_species_prefix(g, spp_b)
+                       for g in row[2].split(", ") if g]
+            for a in a_genes:
+                bucket = a_to_b.setdefault(a, {"og": og_id, "orthologs": []})
+                for b in b_genes:
+                    if b not in bucket["orthologs"]:
+                        bucket["orthologs"].append(b)
+            for b in b_genes:
+                bucket = b_to_a.setdefault(b, {"og": og_id, "orthologs": []})
+                for a in a_genes:
+                    if a not in bucket["orthologs"]:
+                        bucket["orthologs"].append(a)
+    return a_to_b, b_to_a
+
+
+# --- MultipleSequenceAlignments/OG*.fa ---------------------------------------
+def alignments_dir(results_dir):
+    return os.path.join(results_dir, "MultipleSequenceAlignments")
+
+
+def list_alignments(results_dir):
+    """Yield (og_id, absolute_path) for each `OG*.fa` MSA."""
+    ad = alignments_dir(results_dir)
+    if not os.path.isdir(ad):
+        return
+    for name in sorted(os.listdir(ad)):
+        if not name.endswith(".fa"):
+            continue
+        og_id = name[: -len(".fa")]
+        yield og_id, os.path.join(ad, name)
+
+
+def read_msa(fasta_file):
+    """Parse a FASTA (MSA-style) into {gene_id: aligned_sequence}.
+
+    Strips the redundant '<species>||' prefix from each header so lookups
+    line up with Orthogroups.tsv / Orthologues/* / PSI cache."""
+    sequences = {}
+    with open(fasta_file) as fh:
+        faiter = (x[1] for x in itertools.groupby(fh, lambda line: line[0] == ">"))
+        for header in faiter:
+            hdr = next(header)[1:].strip().split(None, 1)[0]
+            seq = "".join(s.strip() for s in next(faiter))
+            sequences[_strip_species_prefix_any(hdr)] = seq.upper()
+    return sequences
+
+
+# --- Species discovery -------------------------------------------------------
+def species_from_orthogroups(orthogroups_tsv):
+    """Return the ordered list of species in the OF run (header of Orthogroups.tsv)."""
+    with open(orthogroups_tsv) as fh:
+        return fh.readline().rstrip("\n").split("\t")[1:]

--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/algorithms/place_query.py
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/algorithms/place_query.py
@@ -1,0 +1,9 @@
+"""Place a query genome's proteins into the enriched OrthoFinder families.
+
+Default: OrthoFinder `-b` insert mode against the pre-computed enriched
+families in <BUNDLE_DIR>/orthofinder_families_enriched/. Wraps the same
+subprocess pattern kb_orthofinder currently uses.
+
+Follow-up: DIAMOND-first placement for a faster path once the algorithm is
+validated (skips MAFFT + tree-build for OGs where DIAMOND is confident).
+"""

--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/algorithms/propagate.py
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/algorithms/propagate.py
@@ -1,0 +1,13 @@
+"""Top ortholog -> PlantSEED function record.
+
+Given a top_ortholog (from psi_refined) and the bundle's cached curation
+lookup, emit both:
+  - the legacy `role # compartment` string (so unchanged plant_fba
+    reconstruction consumes it as-is during the transition)
+  - the new `PS_role_*` stable id list (for the v2 reconstructor)
+
+Arabidopsis-vs-other-species agnostic — the enriched bundle put curated
+non-Arabidopsis proteins into the reference at refbuild time, so a top
+ortholog from Sorghum or a curated moss carries the same weight here as
+one from Arabidopsis.
+"""

--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/algorithms/propagate.py
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/algorithms/propagate.py
@@ -1,13 +1,150 @@
-"""Top ortholog -> PlantSEED function record.
+"""Build the curated-feature index from PlantSEED_Roles.json and turn a
+top-ortholog record into an annotated-genome function string.
 
-Given a top_ortholog (from psi_refined) and the bundle's cached curation
-lookup, emit both:
-  - the legacy `role # compartment` string (so unchanged plant_fba
-    reconstruction consumes it as-is during the transition)
-  - the new `PS_role_*` stable id list (for the v2 reconstructor)
-
-Arabidopsis-vs-other-species agnostic — the enriched bundle put curated
-non-Arabidopsis proteins into the reference at refbuild time, so a top
-ortholog from Sorghum or a curated moss carries the same weight here as
-one from Arabidopsis.
+Ported from
+    plantseed-v3/kb_orthofinder/lib/kb_orthofinder/core/fetch_plantseed_impl.py
+into a standalone library callable that consumes the on-dev
+`Data/PlantSEED_v3/PlantSEED_Roles.json` and produces the SAME
+`role [ / role]* [# compartment]*` string contract that
+`Scripts/PlantSEED_v3/Model/reconstruct_app_impl.py` and
+`plant_fba.reconstruct_plant_metabolism` both consume today.
 """
+
+import json
+
+from .. import paths
+
+
+# Compartment-code -> compartment-name mapping, mirroring the table in
+# kb_orthofinder/core/fetch_plantseed_impl.py. Keys are the localization
+# keys used in PlantSEED_Roles.json; values are the compartment 'name'
+# strings the reconstructor expects.
+COMPARTMENT_MAPPING = {
+    "c":  "cytosol",
+    "g":  "golgi",
+    "w":  "cellwall",
+    "n":  "nucleus",
+    "r":  "endoplasm",
+    "v":  "vacuole",
+    "cv": "vacuole",
+    "d":  "plastid",
+    "cd": "plastid",
+    "m":  "mitochondria",
+    "cm": "mitochondria",
+    "mj": "mitointer",
+    "ce": "extracellular",
+    "x":  "peroxisome",
+    "cx": "peroxisome",
+    "e":  "extracellular",
+    "de": "plastid",
+    "dy": "thylakoid",   # 43 role occurrences on dev — resolves via
+                         # Transport_Compartment_Rules.yaml (`y` wins over `d`)
+    "y":  "thylakoid",   # defensive; not currently used as a single-letter
+                         # localization key in PlantSEED_Roles.json
+}
+
+
+def _parse_feature(feature_str):
+    """PlantSEED_Roles feature strings are 'Species_id||gene_id' or
+    just 'gene_id'. Return (species_or_None, gene_id)."""
+    if "||" in feature_str:
+        src, gid = feature_str.split("||", 1)
+        return src, gid
+    return None, feature_str
+
+
+def build_curated_features(roles_data=None, include_uncurated=False):
+    """Walk PlantSEED_Roles.json and return the curated-feature index.
+
+    Shape:
+        {
+          (species, gene_id): {
+              "roles":        [role_name, ...],       # sorted alphabetically
+              "compartments": [compartment_key, ...], # sorted by single-letter id
+              "function":     "role1 / role2 # cytosol # plastid",
+          },
+          ...
+        }
+
+    `roles_data` — optional pre-loaded list of role dicts; otherwise
+    reads `paths.ROLES_FILE`.
+
+    `include_uncurated` — if True, roles with `include: false` are still
+    walked (matches the behaviour of fetch_plantseed_impl.fetch_features:
+    the include filter is commented out on the roles side, so we mirror
+    that today).
+    """
+    if roles_data is None:
+        with open(paths.ROLES_FILE) as fh:
+            roles_data = json.load(fh)
+
+    per_feature = {}   # (species, gene) -> {'roles': [], 'compartments': []}
+    for entry in roles_data:
+        if not include_uncurated and entry.get("include") is False:
+            pass  # fetch_plantseed_impl.fetch_features has this filter
+                  # commented out today; leave the same behavior here.
+        for feat_str in entry.get("features", []):
+            key = _parse_feature(feat_str)
+            bucket = per_feature.setdefault(
+                key, {"roles": [], "compartments": []}
+            )
+            role_name = entry["role"]
+            if role_name not in bucket["roles"]:
+                bucket["roles"].append(role_name)
+            # The compartment for this feature is the localization key
+            # under which this feature appears in the role's localization dict.
+            for cpt, cpt_features in entry.get("localization", {}).items():
+                if isinstance(cpt_features, dict):
+                    feature_list = list(cpt_features.keys())
+                else:
+                    feature_list = list(cpt_features)
+                if feat_str in feature_list and cpt not in bucket["compartments"]:
+                    bucket["compartments"].append(cpt)
+
+    # Compose the final function string per feature.
+    for key, data in per_feature.items():
+        data["roles"] = sorted(data["roles"])
+        data["compartments"] = sorted(data["compartments"])
+        data["function"] = _compose_function_string(
+            data["roles"], data["compartments"]
+        )
+    return per_feature
+
+
+def _compose_function_string(sorted_roles, sorted_compartments):
+    """`role1 / role2 # cpt-name1 # cpt-name2` — matches
+    fetch_plantseed_impl.fetch_features's output. Unknown compartment
+    keys are dropped silently after a stderr warning."""
+    import sys
+    role_str = " / ".join(sorted_roles)
+    if not sorted_compartments:
+        return role_str
+    mapped = []
+    for cpt in sorted_compartments:
+        if cpt not in COMPARTMENT_MAPPING:
+            print(f"WARNING: no compartment mapping for {cpt!r}", file=sys.stderr)
+            continue
+        mapped.append(COMPARTMENT_MAPPING[cpt])
+    if not mapped:
+        return role_str
+    return role_str + " # " + " # ".join(mapped)
+
+
+def function_for_ortholog(top_ortholog, curated_features):
+    """Look up the function string that should be propagated from
+    `top_ortholog` (a (species, gene_id) tuple) to a query gene.
+
+    Returns None if the ortholog isn't in the curated set."""
+    return (curated_features.get(top_ortholog) or {}).get("function")
+
+
+def curated_features_by_source_species(curated_features):
+    """Group the curated feature index by source species.
+
+    Returns `{species: {gene_id: feature_data}}` so callers can quickly
+    check 'do we have any curated feature in species X?' without walking
+    the full 1666-entry index every time."""
+    by_spp = {}
+    for (spp, gid), data in curated_features.items():
+        by_spp.setdefault(spp, {})[gid] = data
+    return by_spp

--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/algorithms/psi.py
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/algorithms/psi.py
@@ -1,0 +1,164 @@
+"""Compute pairwise sequence identity (PSI) from an OrthoFinder MSA.
+
+Ported from ~/Seq_Home/PlantSEED_Processing_v2/Calculate_Pairwise_Sequence_Identity.py.
+
+PSI for a pair of aligned sequences (X, Y) is:
+    n_match  = count of positions where X[k] == Y[k] and neither is a gap
+    id_x     = n_match / len(X without gaps)
+    id_y     = n_match / len(Y without gaps)
+    psi      = (id_x + id_y) / 2
+
+Cached per-OG under `<OF_RESULTS>/Pairwise_Sequence_Identity/<OG>.txt` so a
+user who runs the annotator repeatedly against the same OF results only pays
+the PSI cost once. File format matches the Processing_v2 script:
+    OG_id \\t gene1:id1 \\t gene2:id2 \\t psi
+"""
+
+import itertools
+import multiprocessing as mp
+import os
+
+from . import orthofinder_io
+
+
+PSI_CACHE_DIRNAME = "Pairwise_Sequence_Identity"
+
+
+def _fmt(x):
+    return f"{x:.2f}"
+
+
+def compute_psi_for_msa(sequences):
+    """Compute PSI for every pair in `sequences` (a {gene_id: aligned_seq} dict).
+
+    Returns a list of tuples (gene1, gene2, id1, id2, psi) with the standard
+    sort order used by the cache (gene1 < gene2)."""
+    features = sorted(sequences.keys())
+    out = []
+    for i in range(len(features) - 1):
+        seq_i = sequences[features[i]]
+        for j in range(i + 1, len(features)):
+            seq_j = sequences[features[j]]
+            n_match = 0
+            for k in range(len(seq_i)):
+                a, b = seq_i[k], seq_j[k]
+                if a == "-" or b == "-":
+                    continue
+                if a == b:
+                    n_match += 1
+            len_i = len(seq_i) - seq_i.count("-")
+            len_j = len(seq_j) - seq_j.count("-")
+            id_i = (n_match / len_i) if len_i > 0 else 0.0
+            id_j = (n_match / len_j) if len_j > 0 else 0.0
+            psi = (id_i + id_j) / 2.0
+            out.append((features[i], features[j], id_i, id_j, psi))
+    return out
+
+
+def write_cache_file(cache_path, og_id, rows):
+    """Write one cached PSI file. Format matches
+    Processing_v2's Calculate_Pairwise_Sequence_Identity.py:
+
+        <og_id>\\t<g1>:<id1>\\t<g2>:<id2>\\t<psi>\\n
+    """
+    with open(cache_path, "w") as fh:
+        for (g1, g2, id1, id2, psi) in rows:
+            fh.write("\t".join([og_id, f"{g1}:{_fmt(id1)}",
+                                f"{g2}:{_fmt(id2)}", _fmt(psi)]) + "\n")
+
+
+def read_cache_file(cache_path):
+    """Load one cached PSI file → list of (gene1, gene2, id1, id2, psi)."""
+    rows = []
+    with open(cache_path) as fh:
+        for line in fh:
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) < 4:
+                continue
+            _og, a_field, b_field, psi_s = parts[0], parts[1], parts[2], parts[3]
+            g1, id1 = a_field.rsplit(":", 1)
+            g2, id2 = b_field.rsplit(":", 1)
+            rows.append((g1, g2, float(id1), float(id2), float(psi_s)))
+    return rows
+
+
+def _worker(args):
+    og_id, msa_path, cache_path = args
+    sequences = orthofinder_io.read_msa(msa_path)
+    rows = compute_psi_for_msa(sequences)
+    write_cache_file(cache_path, og_id, rows)
+    return og_id, len(rows)
+
+
+def ensure_psi_cache(results_dir, cache_dir=None, ogs=None,
+                    n_workers=None, log=print):
+    """Compute PSI for every OG MSA in `results_dir` that isn't already cached.
+
+    Cache defaults to `<results_dir>/Pairwise_Sequence_Identity/`. Pass
+    `cache_dir` to place it elsewhere (useful when results_dir is read-only,
+    e.g., NFS-mounted refdata).
+
+    `ogs` — optional set of og_ids to restrict to (skip work on the ~90 % of
+    OGs that don't touch PlantSEED-curated genes).
+
+    Returns (cache_dir, {og_id: n_pairs_computed_or_cached}).
+    """
+    cache_dir = cache_dir or os.path.join(results_dir, PSI_CACHE_DIRNAME)
+    os.makedirs(cache_dir, exist_ok=True)
+    already = {n[:-len(".txt")] for n in os.listdir(cache_dir) if n.endswith(".txt")}
+
+    todo = []
+    kept_from_cache = {}
+    for og_id, msa_path in orthofinder_io.list_alignments(results_dir):
+        if ogs is not None and og_id not in ogs:
+            continue
+        cache_path = os.path.join(cache_dir, og_id + ".txt")
+        if og_id in already:
+            kept_from_cache[og_id] = None
+            continue
+        todo.append((og_id, msa_path, cache_path))
+
+    log(f"PSI: {len(kept_from_cache)} cached, {len(todo)} to compute "
+        f"(cache dir: {cache_dir})")
+    if not todo:
+        return cache_dir, {og: 0 for og in kept_from_cache}
+
+    n_workers = n_workers or max(1, (os.cpu_count() or 2) - 1)
+    log(f"PSI: computing with {n_workers} workers")
+
+    computed = {}
+    if n_workers == 1:
+        for args in todo:
+            og_id, n = _worker(args)
+            computed[og_id] = n
+    else:
+        with mp.Pool(n_workers) as pool:
+            for og_id, n in pool.imap_unordered(_worker, todo, chunksize=32):
+                computed[og_id] = n
+    result = {og: 0 for og in kept_from_cache}
+    result.update(computed)
+    return cache_dir, result
+
+
+def load_psi_for_ogs(cache_dir, og_ids):
+    """Load PSI rows for every OG in `og_ids`.
+
+    Returns `{og_id: {(g1, g2): psi}}` with (g1, g2) sorted so lookup is
+    order-independent."""
+    out = {}
+    for og_id in og_ids:
+        cache_path = os.path.join(cache_dir, og_id + ".txt")
+        if not os.path.isfile(cache_path):
+            continue
+        pair_psi = {}
+        for (g1, g2, _id1, _id2, psi) in read_cache_file(cache_path):
+            key = (g1, g2) if g1 < g2 else (g2, g1)
+            pair_psi[key] = psi
+        out[og_id] = pair_psi
+    return out
+
+
+def psi_lookup(psi_by_og, og_id, gene_a, gene_b):
+    """Return the cached PSI for (gene_a, gene_b) in og_id, or None."""
+    key = (gene_a, gene_b) if gene_a < gene_b else (gene_b, gene_a)
+    return psi_by_og.get(og_id, {}).get(key)

--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/algorithms/psi_refined.py
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/algorithms/psi_refined.py
@@ -1,14 +1,357 @@
-"""PSI-refined ortholog resolution — port of
-`~/Seq_Home/PlantSEED_Processing_v2/Identify_Functional_Homologs.py` as a
-library.
+"""PSI-refined ortholog + functional-homolog resolution.
 
-Given a query protein placed in an orthogroup (by place_query) plus the
-OG's members and its precomputed PSI matrix, pick the top curated ortholog
-using:
-  - per-species-pair mean PSI as the ortholog/paralog boundary
-  - per-phylum threshold (from phylum_thresholds.json in the bundle) as the
-    final propagation cutoff
+Ports the algorithm from
+    ~/Seq_Home/PlantSEED_Processing_v2/Identify_Functional_Homologs.py
+    ~/Seq_Home/PlantSEED_Processing_v2/Process_Functional_Homologs.py
 
-Returns a top_ortholog record or a "no confident call" marker for
-downstream propagate.py.
+For a query species Q and a reference species R (typically Athaliana_TAIR10):
+
+  1. For each orthogroup containing genes from both Q and R, compute a
+     baseline PSI: the arithmetic mean over PSI values for OF-called
+     ortholog pairs between Q and R in that OG.
+       - If no OF orthologs exist for (Q, R) in this OG, fall back to 0.5.
+
+  2. Walk every cross-species (q_transcript, r_transcript) pair in the OG
+     and classify:
+       - 'O'   OF-called ortholog — accept
+       - 'PAM' paralog above the OG-species-pair mean — accept
+       - 'PAH' paralog above the fallback 0.5 (no baseline) — accept
+       - 'PRM' paralog below mean — reject
+       - 'PRH' paralog below fallback — reject
+     Rejected pairs are dropped from consideration entirely. Accepted pairs
+     are annotation candidates.
+
+  3. Aggregate transcripts to genes:
+       - group query transcripts by query gene (transcript_to_gene)
+       - group ref transcripts by ref gene
+       - PSI(q_gene, r_gene) = MAX over any (q_transcript, r_transcript)
+         accepted candidate pair
+       - Drop ref genes not in the curated set from PlantSEED_Roles.json
+
+  4. Apply the per-phylum PSI threshold and the kb_orthofinder tie-break
+     rules (see annotate_query_gene) to pick the top curated ortholog and
+     propagate its function.
+
+The tie-break rules are lifted verbatim from
+    plantseed-v3/kb_orthofinder/lib/kb_orthofinder/kb_orthofinderImpl.py::propagate_annotation
 """
+
+from collections import Counter, defaultdict
+
+from . import orthofinder_io as _oio
+
+
+UNANNOTATED_LT_THRESHOLD = "Unannotated 1: LESS_THAN_THRESHOLD"
+UNANNOTATED_AMB_HIT      = "Unannotated 3: AMB_HIT"
+UNANNOTATED_NO_REF_HIT   = "Unannotated 4: NO_REF_HIT"
+
+# Fallback baseline used when an OG has no OF-called ortholog pairs
+# between the query and ref species (matches Processing_v2's PAH/PRH split).
+DEFAULT_FALLBACK_BASELINE = 0.5
+
+
+# ----------------------------------------------------------------------------
+# Baseline + candidate classification (the Processing_v2 core)
+# ----------------------------------------------------------------------------
+def _pair_key(a, b):
+    return (a, b) if a < b else (b, a)
+
+
+def compute_og_baselines(orthologues_dict, psi_by_og, sp_gene_to_og,
+                          query_species, ref_species):
+    """Return {og_id: baseline_psi_or_None}.
+
+    For each OG containing at least one OF-called ortholog pair between
+    query_species and ref_species, the baseline is the mean PSI over those
+    pairs (looked up in the per-OG PSI matrix). OGs with no OF orthologs
+    (for this species pair) get None so callers know to use the fallback.
+
+    `orthologues_dict` is the query→ref map from orthofinder_io.load_orthologues
+    (transcript-level, with the '<species>||' prefix already stripped).
+    """
+    sums = defaultdict(float)
+    counts = defaultdict(int)
+    for q_tr, entry in orthologues_dict.items():
+        og_id = entry.get("og") or sp_gene_to_og.get((query_species, q_tr))
+        if not og_id:
+            continue
+        pair_map = psi_by_og.get(og_id)
+        if not pair_map:
+            continue
+        for r_tr in entry.get("orthologs", []):
+            p = pair_map.get(_pair_key(q_tr, r_tr))
+            if p is None:
+                continue
+            sums[og_id] += p
+            counts[og_id] += 1
+    return {og: (sums[og] / counts[og]) for og in counts}
+
+
+def classify_og_pairs(og_id, q_transcripts, r_transcripts,
+                       of_ortholog_pairs, psi_map, baseline,
+                       fallback_baseline=DEFAULT_FALLBACK_BASELINE):
+    """Classify every cross-species (q_tr, r_tr) pair in one OG.
+
+    Args:
+      og_id: the OG identifier (used only for error reporting).
+      q_transcripts: iterable of query-species transcript ids in this OG.
+      r_transcripts: iterable of ref-species transcript ids in this OG.
+      of_ortholog_pairs: set of frozenset({q_tr, r_tr}) pairs OF called orthologs.
+      psi_map: {(g1, g2): psi} for this OG (sorted-pair keys).
+      baseline: mean PSI over OF orthologs for (query, ref) in this OG, or
+                None if no OF orthologs exist.
+      fallback_baseline: threshold to use when baseline is None (default 0.5).
+
+    Returns a list of tuples: (q_tr, r_tr, psi, tag)
+      tag in {'O', 'PAM', 'PAH'} — only accepted pairs are returned.
+    """
+    out = []
+    for q_tr in q_transcripts:
+        for r_tr in r_transcripts:
+            psi = psi_map.get(_pair_key(q_tr, r_tr))
+            if psi is None:
+                continue
+            is_ortho = frozenset({q_tr, r_tr}) in of_ortholog_pairs
+            if is_ortho:
+                out.append((q_tr, r_tr, psi, "O"))
+            elif baseline is not None:
+                if psi > baseline:
+                    out.append((q_tr, r_tr, psi, "PAM"))
+                # else PRM — reject
+            else:
+                if psi > fallback_baseline:
+                    out.append((q_tr, r_tr, psi, "PAH"))
+                # else PRH — reject
+    return out
+
+
+def _of_ortholog_pairs_for_og(orthologues_dict, og_id):
+    """Return the set of frozenset({q_tr, r_tr}) pairs OF called orthologs
+    in the given OG. Used inside classify_og_pairs."""
+    pairs = set()
+    for q_tr, entry in orthologues_dict.items():
+        if entry.get("og") != og_id:
+            continue
+        for r_tr in entry.get("orthologs", []):
+            pairs.add(frozenset({q_tr, r_tr}))
+    return pairs
+
+
+# ----------------------------------------------------------------------------
+# Per-query-gene decision (unchanged tie-break rules)
+# ----------------------------------------------------------------------------
+def annotate_query_gene(query_gene, ref_orthologs, psi_lookup_fn, threshold,
+                         curated_features_for_ref, ref_species):
+    """Decide the annotation for a single query gene.
+
+    Args:
+      query_gene: the query species gene id.
+      ref_orthologs: list of reference-species gene ids (already narrowed to
+                     the curated set AND already filtered by whichever
+                     PSI-threshold rules the caller wants applied).
+      psi_lookup_fn: callable (query_gene, ref_gene) -> psi float or None.
+      threshold: phylum PSI threshold; refs below this are dropped BEFORE
+                 tie-break. Pass `None` to skip this floor (annotate_species
+                 does the more nuanced 'O accepted / PA* threshold-gated'
+                 filter itself and passes threshold=None here).
+      curated_features_for_ref: {ref_gene: {'function': str, ...}}.
+      ref_species: for logging.
+
+    Returns dict with keys 'top_ortholog', 'function', 'psi', 'status'.
+    """
+    if not ref_orthologs:
+        return {"top_ortholog": None, "function": None, "psi": None,
+                "status": "NO_ORTHOLOG"}
+
+    psi_by_ref = {}
+    for ref_gene in ref_orthologs:
+        psi = psi_lookup_fn(query_gene, ref_gene)
+        if psi is not None:
+            psi_by_ref[ref_gene] = psi
+
+    if not psi_by_ref:
+        return {"top_ortholog": None, "function": None, "psi": None,
+                "status": "NO_ORTHOLOG"}
+
+    top_psi = max(psi_by_ref.values())
+    if threshold is not None and top_psi < threshold:
+        return {"top_ortholog": None, "function": None, "psi": top_psi,
+                "status": "LT_THRESHOLD"}
+
+    top_refs = [ref for ref, p in psi_by_ref.items() if p == top_psi]
+
+    # Same three-rule tie-break as kb_orthofinderImpl.propagate_annotation:
+    functions = {}
+    for ref in top_refs:
+        fn = curated_features_for_ref.get(ref, {}).get("function") or "Unannotated"
+        functions.setdefault(fn, []).append(ref)
+
+    if len(functions) == 1:
+        top_ref = top_refs[0]
+    elif len(functions) == 2 and "Unannotated" in functions:
+        annotated_fn = [fn for fn in functions if fn != "Unannotated"][0]
+        top_ref = functions[annotated_fn][0]
+    elif len(functions) == 2:
+        fns_sorted = sorted(functions.keys())
+        if fns_sorted[0] in fns_sorted[1] or fns_sorted[1] in fns_sorted[0]:
+            top_ref = top_refs[0]
+        else:
+            return {"top_ortholog": None, "function": None, "psi": top_psi,
+                    "status": "AMB_HIT"}
+    else:
+        return {"top_ortholog": None, "function": None, "psi": top_psi,
+                "status": "AMB_HIT"}
+
+    fn = curated_features_for_ref.get(top_ref, {}).get("function")
+    if not fn:
+        return {"top_ortholog": None, "function": None, "psi": top_psi,
+                "status": "NO_ORTHOLOG"}
+
+    return {
+        "top_ortholog": (ref_species, top_ref),
+        "function":     fn,
+        "psi":          top_psi,
+        "status":       "ANNOTATED",
+    }
+
+
+# ----------------------------------------------------------------------------
+# Whole-genome annotation
+# ----------------------------------------------------------------------------
+def annotate_species(query_species, ref_species, orthologues_dict,
+                      ogs, psi_by_og, sp_gene_to_og,
+                      curated_features_for_ref, threshold,
+                      admit_paralogs=True,
+                      fallback_baseline=DEFAULT_FALLBACK_BASELINE):
+    """Annotate every query GENE that has at least one curated-ref candidate.
+
+    Candidates are the O + PAM + PAH pairs from Processing_v2's rule
+    (see module docstring). Toggle `admit_paralogs=False` to fall back to
+    the naive "OF orthologs only" path for A/B comparison.
+
+    Args:
+      query_species: e.g. 'Sbicolor_v3.1.1'.
+      ref_species:   e.g. 'Athaliana_TAIR10'.
+      orthologues_dict: {q_tr: {'og': og_id, 'orthologs': [r_tr, ...]}} from
+                        orthofinder_io.load_orthologues.
+      ogs: {og_id: {species: [transcript_id, ...]}} from
+           orthofinder_io.load_orthogroups. Provides the OG membership needed
+           to enumerate paralog candidates.
+      psi_by_og: {og_id: {(t1, t2): psi}}.
+      sp_gene_to_og: {(species, transcript): og_id}.
+      curated_features_for_ref: {ref_gene: feature_data}.
+      threshold: phylum PSI threshold.
+      admit_paralogs: whether to admit PAM / PAH paralogs. Default True.
+      fallback_baseline: threshold for PAH when no OG mean exists (default 0.5).
+
+    Returns:
+      annotations: {query_gene: annotate_query_gene() result} for every
+                   query gene with at least one curated candidate.
+      stats:  Counter of annotation statuses across all annotated calls.
+      pair_stats: Counter of pair-level tags actually kept
+                  ({'O': N, 'PAM': N, 'PAH': N}). Useful for reporting how
+                  much coverage the paralog admission added.
+    """
+    tg = _oio.transcript_to_gene
+
+    # Compute per-OG baseline over OF-called ortholog pairs (query <-> ref).
+    og_baselines = compute_og_baselines(
+        orthologues_dict, psi_by_og, sp_gene_to_og, query_species, ref_species,
+    )
+
+    # Precompute OF ortholog pair sets per OG (used inside classify_og_pairs).
+    ortholog_pairs_by_og = defaultdict(set)
+    for q_tr, entry in orthologues_dict.items():
+        og_id = entry.get("og") or sp_gene_to_og.get((query_species, q_tr))
+        if og_id is None:
+            continue
+        for r_tr in entry.get("orthologs", []):
+            ortholog_pairs_by_og[og_id].add(frozenset({q_tr, r_tr}))
+
+    # Walk every OG containing both query and ref transcripts and classify.
+    # Accumulate accepted (q_tr, r_tr, psi, tag) candidates keyed by query gene.
+    per_query_gene = defaultdict(list)  # {q_gene: [(r_tr, psi, tag), ...]}
+    pair_stats = Counter()
+    for og_id, per_spp in ogs.items():
+        q_transcripts = per_spp.get(query_species) or []
+        r_transcripts = per_spp.get(ref_species) or []
+        if not q_transcripts or not r_transcripts:
+            continue
+        psi_map = psi_by_og.get(og_id)
+        if not psi_map:
+            continue
+        baseline = og_baselines.get(og_id)
+        of_pairs = ortholog_pairs_by_og.get(og_id, set())
+
+        if admit_paralogs:
+            accepted = classify_og_pairs(
+                og_id, q_transcripts, r_transcripts, of_pairs, psi_map,
+                baseline, fallback_baseline,
+            )
+        else:
+            # OF-orthologs-only path (the pre-Processing_v2 behavior).
+            accepted = []
+            for pair in of_pairs:
+                q_tr, r_tr = sorted(pair)
+                p = psi_map.get(_pair_key(q_tr, r_tr))
+                if p is None:
+                    continue
+                # of_pairs is a set of frozenset — need to keep pair direction
+                # aligned with query/ref for downstream aggregation.
+                if q_tr in q_transcripts and r_tr in r_transcripts:
+                    accepted.append((q_tr, r_tr, p, "O"))
+                elif r_tr in q_transcripts and q_tr in r_transcripts:
+                    accepted.append((r_tr, q_tr, p, "O"))
+
+        for q_tr, r_tr, psi, tag in accepted:
+            pair_stats[tag] += 1
+            per_query_gene[tg(q_tr)].append((r_tr, psi, tag))
+
+    # Per query gene: aggregate ref transcripts to ref genes.
+    #
+    # For each (query_gene, ref_gene) pair we track BOTH the max PSI seen
+    # across any accepted pair AND the "best" tag: O outranks PA*. This
+    # matters at the filtering step below — O-tagged candidates skip the
+    # phylum threshold; PA*-tagged candidates must clear it.
+    annotations = {}
+    stats = Counter()
+    for q_gene, cand_list in per_query_gene.items():
+        ref_gene_best = {}   # {ref_gene: (max_psi, has_o_support)}
+        for r_tr, psi, tag in cand_list:
+            r_gene = tg(r_tr)
+            if r_gene not in curated_features_for_ref:
+                continue
+            cur_psi, cur_has_o = ref_gene_best.get(r_gene, (-1.0, False))
+            new_psi = max(cur_psi, psi)
+            new_has_o = cur_has_o or (tag == "O")
+            ref_gene_best[r_gene] = (new_psi, new_has_o)
+
+        # Split-filter: O-supported candidates unconditionally, PA*-only
+        # candidates only if they clear the phylum threshold.
+        filtered_psi = {}
+        for r_gene, (p, has_o) in ref_gene_best.items():
+            if has_o:
+                filtered_psi[r_gene] = p
+            elif p >= threshold:
+                filtered_psi[r_gene] = p
+
+        if not filtered_psi:
+            stats["NO_ORTHOLOG"] += 1
+            annotations[q_gene] = {"top_ortholog": None, "function": None,
+                                    "psi": None, "status": "NO_ORTHOLOG"}
+            continue
+
+        def _lookup(_q, ref, _m=filtered_psi):
+            return _m.get(ref)
+
+        # threshold=None: we already applied the split-filter above; don't
+        # re-apply a uniform threshold that would drop the low-PSI-but-O
+        # candidates we deliberately kept.
+        result = annotate_query_gene(
+            q_gene, list(filtered_psi.keys()), _lookup, None,
+            curated_features_for_ref, ref_species,
+        )
+        annotations[q_gene] = result
+        stats[result["status"]] += 1
+
+    return annotations, stats, pair_stats

--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/algorithms/psi_refined.py
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/algorithms/psi_refined.py
@@ -1,0 +1,14 @@
+"""PSI-refined ortholog resolution — port of
+`~/Seq_Home/PlantSEED_Processing_v2/Identify_Functional_Homologs.py` as a
+library.
+
+Given a query protein placed in an orthogroup (by place_query) plus the
+OG's members and its precomputed PSI matrix, pick the top curated ortholog
+using:
+  - per-species-pair mean PSI as the ortholog/paralog boundary
+  - per-phylum threshold (from phylum_thresholds.json in the bundle) as the
+    final propagation cutoff
+
+Returns a top_ortholog record or a "no confident call" marker for
+downstream propagate.py.
+"""

--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/cli.py
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/cli.py
@@ -1,0 +1,23 @@
+"""`plantseed-annotate` command-line entry point.
+
+Usage (as of scaffold):
+    plantseed-annotate --genome <path.faa|genome.json> \
+                       --tier {kbase,poplar,local} \
+                       [--bundle-version vN] \
+                       [--phylum {eudicot,monocot,basal,auto}] \
+                       [--out <path>]
+
+The KBase App wrapper and the poplar celery task both shell out to this
+same CLI (via python -m plantseed_annotation.cli) so there's one entry
+point, one place to instrument logging + telemetry, and one behavior to
+audit.
+"""
+
+
+def main():
+    """Argparse + dispatch. Filled in at Phase 3 when the poplar CLI ships."""
+    raise NotImplementedError("Phase 3: wire argparse + dispatch")
+
+
+if __name__ == "__main__":
+    main()

--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/cli.py
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/cli.py
@@ -1,23 +1,300 @@
 """`plantseed-annotate` command-line entry point.
 
-Usage (as of scaffold):
-    plantseed-annotate --genome <path.faa|genome.json> \
-                       --tier {kbase,poplar,local} \
-                       [--bundle-version vN] \
-                       [--phylum {eudicot,monocot,basal,auto}] \
-                       [--out <path>]
+Runs the standalone annotator against an OrthoFinder results directory
+plus PlantSEED_Roles.json, producing an annotated genome JSON in the
+shape reconstruct_app_impl.py consumes.
 
-The KBase App wrapper and the poplar celery task both shell out to this
-same CLI (via python -m plantseed_annotation.cli) so there's one entry
-point, one place to instrument logging + telemetry, and one behavior to
-audit.
+Usage:
+
+    plantseed-annotate \\
+        --orthofinder-results /path/to/OrthoFinder/Results_MonDDD \\
+        --query-species Sbicolor_v3.1.1 \\
+        [--ref-species Athaliana_TAIR10] \\
+        [--phylum Monocot] \\
+        [--threshold 0.55] \\
+        [--roles-file /alt/PlantSEED_Roles.json] \\
+        [--psi-cache-dir /alt/writable/PSI_cache] \\
+        [--out annotated_genome.json] \\
+        [--include-unannotated] \\
+        [--workers 8]
+
+Phylum threshold defaults to the phylum's canonical value in paths.PHYLUM_THRESHOLDS_DEFAULT
+(Eudicot=0.60, Monocot=0.55, Basal=0.30). Explicit `--threshold` wins over `--phylum`.
+
+The KBase App wrapper (Phase 4) and poplar celery task (Phase 3) both shell
+out to this same CLI (via `python -m plantseed_annotation.cli`) so there is
+one behaviour to audit and one place to instrument.
 """
 
+import argparse
+import datetime
+import json
+import os
+import sys
 
-def main():
-    """Argparse + dispatch. Filled in at Phase 3 when the poplar CLI ships."""
-    raise NotImplementedError("Phase 3: wire argparse + dispatch")
+from . import paths
+from .algorithms import orthofinder_io, propagate, psi, psi_refined
+from .genome_io import write_annotated_genome
+
+
+def _load_species_phyla(path):
+    """Parse Species_Phyla.txt -> {species: phylum}."""
+    out = {}
+    with open(path) as fh:
+        for line in fh:
+            line = line.rstrip("\r\n")
+            if not line or line.startswith("#"):
+                continue
+            parts = line.split("\t")
+            if len(parts) >= 2:
+                out[parts[0]] = parts[1]
+    return out
+
+
+def _resolve_phylum(query_species, explicit_phylum, phyla_table):
+    """Explicit CLI arg wins; otherwise lookup by exact species match;
+    then by prefix match ('Ptrichocarpa_v4.1' -> 'Ptrichocarpa_' family)."""
+    if explicit_phylum:
+        return explicit_phylum
+    if query_species in phyla_table:
+        return phyla_table[query_species]
+    # Prefix match: species name up to first underscore + '_'
+    prefix = query_species.split("_", 1)[0] + "_"
+    hits = [phy for sp, phy in phyla_table.items() if sp.startswith(prefix)]
+    if hits and len(set(hits)) == 1:
+        return hits[0]
+    return None
+
+
+def _resolve_threshold(explicit_threshold, phylum):
+    if explicit_threshold is not None:
+        return float(explicit_threshold)
+    if phylum in paths.PHYLUM_THRESHOLDS_DEFAULT:
+        return paths.PHYLUM_THRESHOLDS_DEFAULT[phylum]
+    return None
+
+
+def _self_annotate(species, curated_for_ref, out_path, include_unannotated,
+                    metadata_extras):
+    """Round-trip: emit every curated feature as an annotation of itself.
+
+    Used when --query-species == --ref-species. This is the identity path
+    (no orthology, no PSI) — it exists so the annotator can be validated
+    against the curated reference itself (PlantSEED_Roles.json → annotated
+    genome should reproduce the same feature/function map)."""
+    from collections import Counter
+    annotations = {}
+    for ref_gene, entry in curated_for_ref.items():
+        annotations[ref_gene] = {
+            "top_ortholog": (species, ref_gene),
+            "function":     entry["function"],
+            "psi":          1.0,
+            "status":       "ANNOTATED",
+        }
+    stats = Counter(a["status"] for a in annotations.values())
+    metadata = dict(metadata_extras)
+    metadata.update({
+        "annotator":              "plantseed_annotation",
+        "annotator_run_utc":      datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "query_species":          species,
+        "ref_species":            species,
+        "n_annotated_features":   len(annotations),
+        "n_curated_ref_features": len(curated_for_ref),
+        "status_counts":          dict(stats),
+        "mode":                   "self-annotation",
+    })
+    obj = write_annotated_genome(
+        out_path, species, annotations,
+        include_unannotated=include_unannotated, metadata=metadata,
+    )
+    return annotations, stats, obj
+
+
+def _build_argparser():
+    ap = argparse.ArgumentParser(
+        prog="plantseed-annotate",
+        description="Annotate a plant genome from an OrthoFinder results directory + PlantSEED_Roles.json.",
+    )
+    ap.add_argument("--orthofinder-results", required=True,
+        help="Path to an OrthoFinder Results_* directory (containing Orthogroups/, Orthologues/, MultipleSequenceAlignments/).")
+    ap.add_argument("--query-species", required=True,
+        help="Species name as it appears in Orthogroups.tsv's header (e.g. 'Sbicolor_v3.1.1').")
+    ap.add_argument("--ref-species", default="Athaliana_TAIR10",
+        help="Curated reference species. Default: Athaliana_TAIR10.")
+    ap.add_argument("--phylum", choices=("Eudicot", "Monocot", "Basal"),
+        help="Query species phylum. Sets the default PSI threshold. Auto-detected from Species_Phyla.txt if omitted.")
+    ap.add_argument("--threshold", type=float,
+        help="PSI threshold above which to propagate the top-ortholog function. Overrides --phylum.")
+    ap.add_argument("--roles-file",
+        help="Alternate PlantSEED_Roles.json path (default: %s)." % paths.ROLES_FILE)
+    ap.add_argument("--species-phyla-file",
+        help="Alternate Species_Phyla.txt path (default: %s)." % paths.SPECIES_PHYLA_FILE)
+    ap.add_argument("--psi-cache-dir",
+        help="Where to cache per-OG PSI matrices. Default: <orthofinder-results>/Pairwise_Sequence_Identity/.")
+    ap.add_argument("--workers", type=int,
+        help="Number of processes for PSI computation. Default: cpu_count - 1.")
+    ap.add_argument("--out", default="annotated_genome.json",
+        help="Output annotated genome JSON path.")
+    ap.add_argument("--include-unannotated", action="store_true",
+        help="Emit features with functions=['Unannotated'] for query genes that had a curated ortholog but didn't clear the threshold or were ambiguous.")
+    ap.add_argument("--no-admit-paralogs", action="store_true",
+        help="Disable Processing_v2's paralog admission (revert to the pre-Aug-2026 naive path that only considers OF-called orthologs). Use for A/B comparison; default is to admit paralogs above the per-OG baseline.")
+    ap.add_argument("--fallback-baseline", type=float, default=0.5,
+        help="Fallback PSI used to classify paralogs in OGs that have no OF-called orthologs between the query and ref species. Matches Processing_v2's PAH/PRH rule. Default: 0.5.")
+    ap.add_argument("--quiet", action="store_true",
+        help="Suppress progress logs.")
+    return ap
+
+
+def main(argv=None):
+    args = _build_argparser().parse_args(argv)
+
+    def log(msg):
+        if not args.quiet:
+            print(msg, file=sys.stderr, flush=True)
+
+    # --- 1. Resolve inputs ----------------------------------------------------
+    results_dir = os.path.abspath(args.orthofinder_results)
+    ogs_tsv = os.path.join(results_dir, "Orthogroups", "Orthogroups.tsv")
+    if not os.path.isfile(ogs_tsv):
+        sys.exit(f"ERROR: no Orthogroups.tsv under {results_dir}")
+
+    roles_path  = args.roles_file          or paths.ROLES_FILE
+    phyla_path  = args.species_phyla_file  or paths.SPECIES_PHYLA_FILE
+
+    phyla = _load_species_phyla(phyla_path) if os.path.isfile(phyla_path) else {}
+    phylum = _resolve_phylum(args.query_species, args.phylum, phyla)
+    threshold = _resolve_threshold(args.threshold, phylum)
+    if threshold is None:
+        sys.exit(
+            f"ERROR: could not resolve PSI threshold. Pass --threshold explicitly "
+            f"or ensure {args.query_species!r} is in {phyla_path!r} with a known phylum."
+        )
+
+    log(f"[cfg] query_species={args.query_species}  ref_species={args.ref_species}")
+    log(f"[cfg] phylum={phylum!r}  threshold={threshold}")
+    log(f"[cfg] roles_file={roles_path}")
+    log(f"[cfg] orthofinder_results={results_dir}")
+
+    # --- 2. Load curated features (from PlantSEED_Roles) ---------------------
+    with open(roles_path) as fh:
+        roles_data = json.load(fh)
+    curated = propagate.build_curated_features(roles_data)
+    curated_by_spp = propagate.curated_features_by_source_species(curated)
+    curated_for_ref = curated_by_spp.get(args.ref_species, {})
+    if not curated_for_ref:
+        sys.exit(
+            f"ERROR: no curated features for ref-species {args.ref_species!r} in {roles_path}. "
+            f"Species with curated features: {sorted(curated_by_spp)}."
+        )
+    log(f"[curation] {len(curated_for_ref)} curated features for {args.ref_species}")
+
+    # --- 3. Load orthogroups + orthologues -----------------------------------
+    ogs, species_in_run = orthofinder_io.load_orthogroups(ogs_tsv)
+    log(f"[of] {len(ogs)} orthogroups; species in run: {species_in_run}")
+    if args.query_species not in species_in_run:
+        sys.exit(
+            f"ERROR: --query-species {args.query_species!r} not in Orthogroups.tsv header. "
+            f"Present: {species_in_run}"
+        )
+    if args.ref_species not in species_in_run:
+        sys.exit(
+            f"ERROR: --ref-species {args.ref_species!r} not in Orthogroups.tsv header. "
+            f"Present: {species_in_run}"
+        )
+
+    if args.query_species == args.ref_species:
+        # Self-annotation: no Orthologues/X__v__X.tsv exists. Emit every
+        # curated feature as an annotation of itself — this is the round-trip
+        # validation path (the annotator should reproduce PlantSEED_Roles.json's
+        # own curation 1:1 on the reference species).
+        log(f"[of] self-annotation on {args.query_species} — emitting curated features directly")
+        annotations, stats, obj = _self_annotate(
+            args.query_species, curated_for_ref, args.out,
+            include_unannotated=args.include_unannotated,
+            metadata_extras={"phylum": phylum, "psi_threshold": None,
+                             "roles_file": roles_path,
+                             "orthofinder_results": results_dir},
+        )
+        log(f"[annot] status counts: {dict(stats)}")
+        log(f"[out] wrote {args.out}  ({len(obj['features'])} features)")
+        return 0
+
+    orth_tsv = orthofinder_io.orthologues_path(
+        results_dir, args.query_species, args.ref_species,
+    )
+    if not orth_tsv:
+        sys.exit(
+            f"ERROR: no Orthologues/{args.query_species}__v__{args.ref_species}.tsv "
+            f"under {results_dir}."
+        )
+    q_to_r, _r_to_q = orthofinder_io.load_orthologues(orth_tsv)
+    log(f"[of] {len(q_to_r)} query genes with orthologs in {args.ref_species}")
+
+    # --- 4. Restrict to OGs that touch curated ref genes ---------------------
+    #    (skip PSI computation on ~90% of OGs that have no curated ref genes).
+    #    sp_gene_to_og is transcript-level (Orthogroups.tsv cells are transcripts);
+    #    curated_for_ref is gene-level (PlantSEED_Roles.json). Walk the reverse
+    #    index once and keep OGs whose transcript-level ref genes normalize to
+    #    a curated gene id.
+    sp_gene_to_og = orthofinder_io.species_gene_to_og_index(ogs)
+    tg = orthofinder_io.transcript_to_gene
+    curated_ogs = set()
+    for (spp, transcript_id), og_id in sp_gene_to_og.items():
+        if spp != args.ref_species:
+            continue
+        if tg(transcript_id) in curated_for_ref:
+            curated_ogs.add(og_id)
+    log(f"[of] {len(curated_ogs)} OGs touch curated {args.ref_species} genes")
+
+    # --- 5. Ensure PSI cache for those OGs -----------------------------------
+    cache_dir, _stats = psi.ensure_psi_cache(
+        results_dir, cache_dir=args.psi_cache_dir,
+        ogs=curated_ogs, n_workers=args.workers, log=log,
+    )
+    psi_by_og = psi.load_psi_for_ogs(cache_dir, curated_ogs)
+    log(f"[psi] loaded PSI for {len(psi_by_og)} OGs")
+
+    # --- 6. Annotate ----------------------------------------------------------
+    annotations, stats, pair_stats = psi_refined.annotate_species(
+        args.query_species, args.ref_species,
+        q_to_r, ogs, psi_by_og, sp_gene_to_og,
+        curated_for_ref, threshold,
+        admit_paralogs=not args.no_admit_paralogs,
+        fallback_baseline=args.fallback_baseline,
+    )
+    log(f"[annot] status counts: {dict(stats)}")
+    log(f"[annot] pair-level tags kept: {dict(pair_stats)}   "
+        f"(O=OF ortholog, PAM=paralog above OG mean, PAH=paralog above fallback {args.fallback_baseline})")
+
+    n_annotated = sum(1 for a in annotations.values() if a["status"] == "ANNOTATED")
+    log(f"[annot] annotated {n_annotated} query gene(s) out of {len(annotations)} that had a curated candidate")
+
+    # --- 7. Write annotated genome JSON --------------------------------------
+    metadata = {
+        "annotator": "plantseed_annotation",
+        "annotator_run_utc": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "query_species": args.query_species,
+        "ref_species":   args.ref_species,
+        "phylum":        phylum,
+        "psi_threshold": threshold,
+        "admit_paralogs": not args.no_admit_paralogs,
+        "fallback_baseline": args.fallback_baseline,
+        "orthofinder_results": results_dir,
+        "roles_file":    roles_path,
+        "psi_cache_dir": cache_dir,
+        "status_counts": dict(stats),
+        "pair_stats":    dict(pair_stats),
+        "n_annotated_features": n_annotated,
+        "n_curated_ref_features": len(curated_for_ref),
+    }
+    obj = write_annotated_genome(
+        args.out, args.query_species, annotations,
+        include_unannotated=args.include_unannotated, metadata=metadata,
+    )
+    log(f"[out] wrote {args.out}  ({len(obj['features'])} features)")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/config.py
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/config.py
@@ -1,0 +1,65 @@
+"""Tier configuration — CPU/RAM/refdata targets for the three runtime
+environments the annotator supports.
+
+Consumers pick a tier and the dispatch layer sizes work accordingly:
+
+  kbase  — 2 cores, 22 GB RAM, refdata bundle <= 10 GB
+           (the KBase SDK worker box; nested SDK calls run serially, no HPC)
+  poplar — 8 cores per celery worker, 128 GB RAM, refdata on /kb/data
+           (Argonne-side celery worker behind ModelSEED.org; scale by adding
+           worker replicas, not by raising per-worker concurrency)
+  local  — as-much-as-you-have; refdata bundle downloaded / mounted per user
+           (offline dev, local Docker)
+
+See the plan (§Resource picture, §Distribution pipeline) for the tier
+rationale.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TierConfig:
+    name: str
+    cpu_max: int
+    ram_gb_max: int
+    refdata_gb_max: int
+    concurrency: int
+    notes: str
+
+
+KBASE = TierConfig(
+    name="kbase",
+    cpu_max=2,
+    ram_gb_max=22,
+    refdata_gb_max=10,
+    concurrency=1,
+    notes="KBase SDK worker; nested SDK calls run serially; no HPC.",
+)
+
+POPLAR = TierConfig(
+    name="poplar",
+    cpu_max=8,
+    ram_gb_max=128,
+    refdata_gb_max=200,
+    concurrency=8,
+    notes="Argonne celery worker behind ModelSEED.org; scale by adding worker replicas.",
+)
+
+LOCAL = TierConfig(
+    name="local",
+    cpu_max=0,          # unbounded
+    ram_gb_max=0,       # unbounded
+    refdata_gb_max=0,   # unbounded
+    concurrency=1,
+    notes="Local Docker / dev machine; user provides limits.",
+)
+
+BY_NAME = {t.name: t for t in (KBASE, POPLAR, LOCAL)}
+
+
+def get(name):
+    """Return the TierConfig for `name` (kbase|poplar|local)."""
+    if name not in BY_NAME:
+        raise ValueError(f"unknown tier {name!r} — expected one of {sorted(BY_NAME)}")
+    return BY_NAME[name]

--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/dispatch.py
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/dispatch.py
@@ -1,0 +1,13 @@
+"""Choose the algorithm chain for a given (genome, tier) pair.
+
+Primary path (all tiers):
+  place_query.run(...)  ->  psi_refined.identify_orthologs(...)  ->
+  propagate.function_from(...)
+
+Fast path (kbase tier only, once bundle grows past 10 GB):
+  kmer.annotate(...)  as pre-filter, escalate to primary path only for
+  proteins the kmer index couldn't confidently call.
+
+Per-phylum defaults from phylum_thresholds.json in the bundle; caller can
+override via config for A/B experiments.
+"""

--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/emit.py
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/emit.py
@@ -1,0 +1,13 @@
+"""Serialize a per-feature annotation to both the legacy string contract
+and the new stable-ID form.
+
+Legacy string (consumed by unchanged plant_fba.reconstruct_plant_metabolism
+during the migration):
+    `<role1> / <role2> # <compartment1> # <compartment2>`
+
+Stable IDs (consumed by v2 reconstructor):
+    ["PS_role_abc123", "PS_role_def456"]
+
+The bundle's curation/ subdir provides the string <-> id mapping so both
+forms can be emitted from a single top-ortholog record.
+"""

--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/genome_io.py
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/genome_io.py
@@ -1,16 +1,52 @@
-"""Genome format adapters.
+"""Serialize an annotated genome in the shape
+`Scripts/PlantSEED_v3/Model/reconstruct_app_impl.py` consumes.
 
-Two shapes the annotator has to accept and emit:
+The reconstructor reads:
 
-  - KBase `KBaseGenomes.Genome` object (dict-of-dicts JSON with features,
-    mrnas, cdss arrays and protein_translation on each). What the SDK App
-    wrapper hands in and the reconstructor consumes.
+    {
+      "id": "...",
+      "features": [
+        {"id": "geneA", "functions": ["role1 / role2 # cytosol"]},
+        {"id": "geneB", "functions": ["role3 # plastid"]},
+        ...
+      ]
+    }
 
-  - Standalone protein FASTA (what poplar celery gets from a website upload
-    or a local user runs from a checkout).
-
-genome_io.load() returns a normalized {feature_id: protein_seq} dict;
-genome_io.write_annotations() writes annotations back into the source
-shape (feature['functions'] arrays for KBase Genome; a `.functions.tsv`
-sidecar for standalone FASTA).
+so this module writes exactly that. Unannotated features are omitted by
+default (reconstruct skips them anyway); use `include_unannotated=True` to
+include them with `["Unannotated"]`.
 """
+
+import json
+
+
+def build_annotated_genome(genome_id, annotations, include_unannotated=False):
+    """Turn annotate_species()'s output into a reconstructor-compatible dict.
+
+    `annotations` — {query_gene: annotate_query_gene() result}. Only entries
+    with status == 'ANNOTATED' and a non-None function contribute a
+    feature; the rest are skipped (or emitted as Unannotated if opted-in).
+    """
+    features = []
+    for gene, ann in sorted(annotations.items()):
+        fn = ann.get("function")
+        if ann.get("status") == "ANNOTATED" and fn:
+            features.append({"id": gene, "functions": [fn]})
+        elif include_unannotated:
+            features.append({"id": gene, "functions": ["Unannotated"]})
+    return {"id": genome_id, "features": features}
+
+
+def write_annotated_genome(path, genome_id, annotations,
+                            include_unannotated=False, metadata=None):
+    """Write the annotated genome JSON to `path`.
+
+    `metadata` — optional dict merged into the top level under 'metadata';
+    lets callers record OF results dir, phylum, threshold, timestamp, etc.
+    """
+    obj = build_annotated_genome(genome_id, annotations, include_unannotated)
+    if metadata:
+        obj["metadata"] = metadata
+    with open(path, "w") as fh:
+        json.dump(obj, fh, indent=2, sort_keys=True)
+    return obj

--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/genome_io.py
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/genome_io.py
@@ -1,0 +1,16 @@
+"""Genome format adapters.
+
+Two shapes the annotator has to accept and emit:
+
+  - KBase `KBaseGenomes.Genome` object (dict-of-dicts JSON with features,
+    mrnas, cdss arrays and protein_translation on each). What the SDK App
+    wrapper hands in and the reconstructor consumes.
+
+  - Standalone protein FASTA (what poplar celery gets from a website upload
+    or a local user runs from a checkout).
+
+genome_io.load() returns a normalized {feature_id: protein_seq} dict;
+genome_io.write_annotations() writes annotations back into the source
+shape (feature['functions'] arrays for KBase Genome; a `.functions.tsv`
+sidecar for standalone FASTA).
+"""

--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/paths.py
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/paths.py
@@ -48,13 +48,37 @@ COMPLEXES_FILE = _env(
     "PLANTSEED_ANNOT_COMPLEXES_FILE",
     os.path.join(_REPO_ROOT, "Data", "PlantSEED_v3", "PlantSEED_Complexes.json"),
 )
+COMPARTMENTS_FILE = _env(
+    "PLANTSEED_ANNOT_COMPARTMENTS_FILE",
+    os.path.join(
+        _REPO_ROOT, "Data", "PlantSEED_v3", "Compartments",
+        "PlantSEED_Compartments.json",
+    ),
+)
+SPECIES_PHYLA_FILE = _env(
+    "PLANTSEED_ANNOT_SPECIES_PHYLA_FILE",
+    os.path.join(
+        _REPO_ROOT, "Scripts", "PlantSEED_v3", "KBase",
+        "Species_Phyla.txt",
+    ),
+)
+
+# Per-phylum PSI thresholds from Scripts/PlantSEED_v3/KBase/Annotate_Single_Genome_in_KBase.pl.
+# CLI --phylum-threshold overrides for a single run; env override for a whole
+# session / test suite.
+PHYLUM_THRESHOLDS_DEFAULT = {
+    "Eudicot": 0.60,
+    "Monocot": 0.55,
+    "Basal":   0.30,
+}
 
 
 def refresh_from_env():
     """Re-read paths from the environment. Tests call this after setting
     PLANTSEED_ANNOT_* env vars in a fixture so the module-level constants
     reflect the new values."""
-    global BUNDLE_ROOT, BUNDLE_VERSION, BUNDLE_DIR, ROLES_FILE, COMPLEXES_FILE
+    global BUNDLE_ROOT, BUNDLE_VERSION, BUNDLE_DIR
+    global ROLES_FILE, COMPLEXES_FILE, COMPARTMENTS_FILE, SPECIES_PHYLA_FILE
     BUNDLE_ROOT = _env("PLANTSEED_ANNOT_BUNDLE_ROOT", "/kb/data/plantseed_annotation")
     BUNDLE_VERSION = _env("PLANTSEED_ANNOT_BUNDLE_VERSION", "latest")
     BUNDLE_DIR = _env(
@@ -68,4 +92,18 @@ def refresh_from_env():
     COMPLEXES_FILE = _env(
         "PLANTSEED_ANNOT_COMPLEXES_FILE",
         os.path.join(_REPO_ROOT, "Data", "PlantSEED_v3", "PlantSEED_Complexes.json"),
+    )
+    COMPARTMENTS_FILE = _env(
+        "PLANTSEED_ANNOT_COMPARTMENTS_FILE",
+        os.path.join(
+            _REPO_ROOT, "Data", "PlantSEED_v3", "Compartments",
+            "PlantSEED_Compartments.json",
+        ),
+    )
+    SPECIES_PHYLA_FILE = _env(
+        "PLANTSEED_ANNOT_SPECIES_PHYLA_FILE",
+        os.path.join(
+            _REPO_ROOT, "Scripts", "PlantSEED_v3", "KBase",
+            "Species_Phyla.txt",
+        ),
     )

--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/paths.py
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/paths.py
@@ -1,0 +1,71 @@
+"""Filesystem paths used by the annotator.
+
+Every path is overridable via a PLANTSEED_ANNOT_* environment variable so the
+test suite (and any caller pinning a specific bundle version) can point the
+package at an alternative location without touching the module source.
+
+Mirrors the layout / conventions of plantseed_curation.paths — see that
+module for the pattern rationale.
+"""
+
+import os
+
+
+def _env(name, default):
+    return os.environ.get(name, default)
+
+
+# This package lives at Scripts/PlantSEED_v3/Annotation/plantseed_annotation/.
+# Climb four levels to reach the repo root (where Data/ lives).
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ANNOTATION_ROOT = os.path.dirname(_HERE)
+_REPO_ROOT = os.path.normpath(os.path.join(_ANNOTATION_ROOT, "..", "..", ".."))
+
+
+# Refdata bundle location. Populated at Phase 1 by refbuild/ scripts; consumed
+# by reference.py + algorithms/* at annotation time.
+#
+# Default points at /kb/data (the KBase refdata NFS mount that poplar
+# already has). Override via env for local dev.
+BUNDLE_ROOT = _env(
+    "PLANTSEED_ANNOT_BUNDLE_ROOT",
+    "/kb/data/plantseed_annotation",
+)
+BUNDLE_VERSION = _env("PLANTSEED_ANNOT_BUNDLE_VERSION", "latest")
+BUNDLE_DIR = _env(
+    "PLANTSEED_ANNOT_BUNDLE_DIR",
+    os.path.join(BUNDLE_ROOT, BUNDLE_VERSION),
+)
+
+# Curation source-of-truth files this package reads at bundle build time.
+# Default is co-located inside the repo (Data/PlantSEED_v3/) so refbuild
+# can run offline on a fresh clone.
+ROLES_FILE = _env(
+    "PLANTSEED_ANNOT_ROLES_FILE",
+    os.path.join(_REPO_ROOT, "Data", "PlantSEED_v3", "PlantSEED_Roles.json"),
+)
+COMPLEXES_FILE = _env(
+    "PLANTSEED_ANNOT_COMPLEXES_FILE",
+    os.path.join(_REPO_ROOT, "Data", "PlantSEED_v3", "PlantSEED_Complexes.json"),
+)
+
+
+def refresh_from_env():
+    """Re-read paths from the environment. Tests call this after setting
+    PLANTSEED_ANNOT_* env vars in a fixture so the module-level constants
+    reflect the new values."""
+    global BUNDLE_ROOT, BUNDLE_VERSION, BUNDLE_DIR, ROLES_FILE, COMPLEXES_FILE
+    BUNDLE_ROOT = _env("PLANTSEED_ANNOT_BUNDLE_ROOT", "/kb/data/plantseed_annotation")
+    BUNDLE_VERSION = _env("PLANTSEED_ANNOT_BUNDLE_VERSION", "latest")
+    BUNDLE_DIR = _env(
+        "PLANTSEED_ANNOT_BUNDLE_DIR",
+        os.path.join(BUNDLE_ROOT, BUNDLE_VERSION),
+    )
+    ROLES_FILE = _env(
+        "PLANTSEED_ANNOT_ROLES_FILE",
+        os.path.join(_REPO_ROOT, "Data", "PlantSEED_v3", "PlantSEED_Roles.json"),
+    )
+    COMPLEXES_FILE = _env(
+        "PLANTSEED_ANNOT_COMPLEXES_FILE",
+        os.path.join(_REPO_ROOT, "Data", "PlantSEED_v3", "PlantSEED_Complexes.json"),
+    )

--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/reconstruct_cli.py
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/reconstruct_cli.py
@@ -1,0 +1,120 @@
+"""`plantseed-reconstruct` — thin CLI wrapper around
+`Scripts/PlantSEED_v3/Model/reconstruct_app_impl.py::ReconstructAppImpl`.
+
+Consumes:
+  - an annotated genome JSON (as produced by plantseed-annotate)
+  - a template JSON (default: Scripts/PlantSEED_v3/Template/PlantSEED_Neutral_Template.json)
+  - a compartments JSON (default: Data/PlantSEED_v3/Compartments/PlantSEED_Compartments.json)
+
+Produces an FBAModel-shaped JSON matching what
+`reconstruct_app_impl.py::main` writes today (KBase-native format).
+
+The wrapper is thin: argparse + a call into ReconstructAppImpl. All
+algorithm changes should land in reconstruct_app_impl.py itself.
+"""
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+
+from . import paths
+
+
+def _load_reconstruct_impl():
+    """Import ReconstructAppImpl from Scripts/PlantSEED_v3/Model/reconstruct_app_impl.py
+    (which isn't packaged, so we load it by path)."""
+    here = os.path.dirname(os.path.abspath(__file__))
+    repo_root = os.path.normpath(os.path.join(here, "..", "..", "..", ".."))
+    impl_path = os.path.join(
+        repo_root, "Scripts", "PlantSEED_v3", "Model", "reconstruct_app_impl.py",
+    )
+    if not os.path.isfile(impl_path):
+        sys.exit(f"ERROR: reconstruct_app_impl.py not found at {impl_path}")
+    spec = importlib.util.spec_from_file_location("reconstruct_app_impl", impl_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.ReconstructAppImpl
+
+
+def _default_template_path():
+    here = os.path.dirname(os.path.abspath(__file__))
+    repo_root = os.path.normpath(os.path.join(here, "..", "..", "..", ".."))
+    return os.path.join(
+        repo_root, "Scripts", "PlantSEED_v3", "Template",
+        "PlantSEED_Biomass_Template.json",
+    )
+
+
+def _build_argparser():
+    ap = argparse.ArgumentParser(
+        prog="plantseed-reconstruct",
+        description="Reconstruct a plant metabolic model from an annotated "
+                    "genome JSON + PlantSEED template.",
+    )
+    ap.add_argument("--genome", required=True,
+        help="Path to the annotated genome JSON (from plantseed-annotate).")
+    ap.add_argument("--template", default=None,
+        help="Path to the PlantSEED template JSON. Default: %s"
+             % _default_template_path())
+    ap.add_argument("--compartments", default=None,
+        help="Path to PlantSEED_Compartments.json. Default: %s"
+             % paths.COMPARTMENTS_FILE)
+    ap.add_argument("--model-id", default=None,
+        help="Model id / name. Default: genome_id + '_model'.")
+    ap.add_argument("--out", required=True,
+        help="Output FBAModel JSON path.")
+    ap.add_argument("--log-rxn", default=None,
+        help="Optional reaction id to trace verbosely during reconstruction.")
+    ap.add_argument("--quiet", action="store_true")
+    return ap
+
+
+def main(argv=None):
+    args = _build_argparser().parse_args(argv)
+
+    def log(msg):
+        if not args.quiet:
+            print(msg, file=sys.stderr, flush=True)
+
+    genome_path       = os.path.abspath(args.genome)
+    template_path     = os.path.abspath(args.template or _default_template_path())
+    compartments_path = os.path.abspath(args.compartments or paths.COMPARTMENTS_FILE)
+
+    log(f"[cfg] genome:       {genome_path}")
+    log(f"[cfg] template:     {template_path}")
+    log(f"[cfg] compartments: {compartments_path}")
+
+    for p in (genome_path, template_path, compartments_path):
+        if not os.path.isfile(p):
+            sys.exit(f"ERROR: file not found: {p}")
+
+    with open(genome_path) as fh:
+        genome_obj = json.load(fh)
+    with open(template_path) as fh:
+        template_obj = json.load(fh)
+    with open(compartments_path) as fh:
+        compartments = json.load(fh)
+
+    model_id = args.model_id or (genome_obj.get("id", "model") + "_model")
+
+    ReconstructAppImpl = _load_reconstruct_impl()
+    recon = ReconstructAppImpl()
+    recon._set_objects({"genome": genome_obj, "template": template_obj})
+
+    input_params = {"id": model_id, "name": model_id, "cpts": compartments}
+    log(f"[recon] running reconstruct_metabolism (model_id={model_id})")
+    metabolism = recon.reconstruct_metabolism(input_params, log_rxn=args.log_rxn)
+
+    with open(args.out, "w") as fh:
+        json.dump(metabolism, fh, indent=4, sort_keys=True)
+    log(f"[out] wrote {args.out}")
+    log(f"      modelreactions:   {len(metabolism.get('modelreactions', []))}")
+    log(f"      modelcompounds:   {len(metabolism.get('modelcompounds', []))}")
+    log(f"      biomasses:        {len(metabolism.get('biomasses', []))}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/refbuild/__init__.py
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/refbuild/__init__.py
@@ -1,0 +1,19 @@
+"""Offline scripts that build a versioned refdata bundle under
+<BUNDLE_ROOT>/<version>/.
+
+Runs on poplar (has SHOOT, OrthoFinder, DIAMOND, MAFFT + the compute), not
+inside the KBase SDK container (too big, wrong host).
+
+Order (Phase 1):
+  1. build_orthofinder_db       — baseline OrthoFinder MSA-mode run over Phytozome
+  2. build_shoot_db             — SHOOT database from that OrthoFinder run
+  3. enrich_with_curated_proteins — SHOOT-place each non-Arabidopsis PlantSEED-
+                                    curated UniProt protein into its OG's fasta+MSA+tree
+  4. build_psi_matrices         — per-OG pairwise sequence identity over enriched families
+  5. stamp_version              — write manifest.json + finalize the bundle dir
+
+Distribution (Phase 6):
+  Bundle build is triggered by a GitHub Action on merges to dev that touch
+  Data/PlantSEED_v3/PlantSEED_Roles.json or PlantSEED_Complexes.json, via
+  a webhook to a poplar-side listener that invokes stamp_version's CLI.
+"""

--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/refbuild/build_orthofinder_db.py
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/refbuild/build_orthofinder_db.py
@@ -1,0 +1,9 @@
+"""Baseline OrthoFinder MSA-mode run on the Phytozome reference species
+set, producing per-OG fastas + MSAs + gene trees.
+
+Wraps the same OrthoFinder command kb_orthofinder currently runs; output
+goes to `<BUNDLE_DIR>/orthofinder_families_enriched/` (before enrichment)
+or a tmp dir that `enrich_with_curated_proteins` then mutates in place.
+
+Filled in at Phase 1.
+"""

--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/refbuild/build_psi_matrices.py
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/refbuild/build_psi_matrices.py
@@ -1,0 +1,13 @@
+"""Compute per-OG pairwise sequence identity matrices over the enriched
+families, keyed by every member (Arabidopsis + curated non-Arabidopsis
+proteins alike).
+
+Port of `~/Seq_Home/PlantSEED_Processing_v2/Calculate_Pairwise_Sequence_Identity.py`
+into a library callable, with the enriched families as input rather than
+raw OrthoFinder output.
+
+Output: `<BUNDLE_DIR>/psi_matrices/OG*.tsv` — one file per OG. Consumed
+at annotation time by algorithms.psi_refined.
+
+Filled in at Phase 1.
+"""

--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/refbuild/build_shoot_db.py
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/refbuild/build_shoot_db.py
@@ -1,0 +1,14 @@
+"""Turn the OrthoFinder results directory into a SHOOT database.
+
+Wraps SHOOT's own tools:
+    python create_shoot_db.py RESULTS_DIRECTORY full
+    python bifurcating_trees.py RESULTS_DIRECTORY   # for EPA-ng compat
+
+Output: `<BUNDLE_DIR>/shoot_db/`, ready for `shoot INPUT_FASTA SHOOT_DB`
+(consumed by enrich_with_curated_proteins).
+
+SHOOT deps: ete3, sklearn, biopython, DIAMOND, MAFFT, EPA-ng + gappa
+(or IQ-TREE as substitute). See github.com/davidemms/SHOOT.
+
+Filled in at Phase 1.
+"""

--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/refbuild/enrich_with_curated_proteins.py
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/refbuild/enrich_with_curated_proteins.py
@@ -1,0 +1,16 @@
+"""SHOOT-place each non-Arabidopsis PlantSEED-curated UniProt protein into
+its OrthoFinder gene tree, then insert it into the corresponding OG's
+fasta + MSA + tree.
+
+This is the step that puts sorghum dhurrin enzymes, taxol-pathway
+proteins, Brassica MAMs, and other non-Arabidopsis specialists into the
+reference — without it, downstream genomes can never be annotated for
+specialized metabolic pathways Arabidopsis lacks.
+
+Incremental caching: only re-SHOOTs proteins whose UniProt ID + sequence
+hash is new since the previous bundle version. Cached placements are
+carried over from vN-1. This is what makes the Phase 6 GitHub-Action-driven
+bundle rebuild fast enough to run on every merge.
+
+Filled in at Phase 1.
+"""

--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/refbuild/manifest_schema.json
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/refbuild/manifest_schema.json
@@ -1,0 +1,147 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "plantseed_annotation refdata bundle manifest",
+  "description": "Manifest for a versioned refdata bundle under <BUNDLE_ROOT>/<version>/. Written by refbuild/stamp_version.py; consumed by plantseed_annotation.reference at annotation time.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "bundle_version",
+    "created_utc",
+    "sources",
+    "tool_versions",
+    "contents",
+    "totals",
+    "curated_non_arabidopsis"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Version of THIS manifest schema. Bumped when the manifest structure changes."
+    },
+
+    "bundle_version": {
+      "type": "string",
+      "pattern": "^v\\d+(\\.\\d+)?$",
+      "description": "Human-readable version tag (v1, v2, v2.1, ...). Monotonic. Advances on any input change: new curator PR, new Phytozome release, new tool major version.",
+      "examples": ["v1", "v2", "v2.1"]
+    },
+
+    "created_utc": {
+      "type": "string",
+      "format": "date-time",
+      "description": "UTC timestamp when refbuild/stamp_version.py finalized this bundle."
+    },
+
+    "sources": {
+      "type": "object",
+      "required": ["roles_json_sha", "complexes_json_sha", "phytozome_release", "shoot_db_build_id"],
+      "properties": {
+        "roles_json_sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{7,40}$",
+          "description": "git SHA of Data/PlantSEED_v3/PlantSEED_Roles.json at bundle build time. This is the single most important pin: any curator PR that touches roles changes this SHA and forces a bundle rebuild."
+        },
+        "complexes_json_sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{7,40}$",
+          "description": "git SHA of Data/PlantSEED_v3/PlantSEED_Complexes.json at bundle build time."
+        },
+        "phytozome_release": {
+          "type": "string",
+          "description": "Phytozome release identifier used for the baseline OrthoFinder run (e.g., 'V12', 'V13').",
+          "examples": ["V12", "V13"]
+        },
+        "shoot_db_build_id": {
+          "type": "string",
+          "description": "SHOOT database build identifier — hash of the OrthoFinder results directory + SHOOT tool version. Changes when the SHOOT db was regenerated even if roles didn't change."
+        },
+        "curation_repo_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Upstream repo the roles/complexes files were sourced from. Almost always github.com/ModelSEED/PlantSEED but recorded for provenance."
+        }
+      }
+    },
+
+    "tool_versions": {
+      "type": "object",
+      "description": "Versions of every external tool involved in building the bundle. Used by verify() to warn on version drift between build-time and run-time environments.",
+      "properties": {
+        "orthofinder": { "type": "string" },
+        "diamond": { "type": "string" },
+        "mafft": { "type": "string" },
+        "fasttree": { "type": "string" },
+        "shoot": { "type": "string" },
+        "epa_ng": { "type": "string" },
+        "gappa": { "type": "string" },
+        "plantseed_annotation": { "type": "string", "description": "This package's version at bundle build time." }
+      }
+    },
+
+    "contents": {
+      "type": "object",
+      "description": "Per-file SHA-256 for every artifact inside the bundle directory. reference.verify() diffs on-disk hashes against these.",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["sha256", "bytes"],
+        "properties": {
+          "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+          "bytes":  { "type": "integer", "minimum": 0 }
+        }
+      }
+    },
+
+    "totals": {
+      "type": "object",
+      "required": ["bytes_total", "og_count", "protein_count"],
+      "properties": {
+        "bytes_total": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total on-disk bytes. Compared to config.get(tier).refdata_gb_max at load time; over-cap loads fail on the KBase tier."
+        },
+        "og_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of orthogroups in orthofinder_families_enriched/. Pruning kept only PlantSEED-adjacent OGs + close neighbors."
+        },
+        "protein_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total protein sequences across all OGs (Arabidopsis + curated non-Arabidopsis + reference-species neighbors)."
+        }
+      }
+    },
+
+    "curated_non_arabidopsis": {
+      "type": "array",
+      "description": "Every non-Arabidopsis PlantSEED-curated protein that was SHOOT-placed into the enriched families this run. Recorded here so the manifest itself documents which specialized pathways the bundle covers.",
+      "items": {
+        "type": "object",
+        "required": ["source", "id", "og", "sha256"],
+        "properties": {
+          "source": { "type": "string", "description": "e.g., 'UniProt', 'Phytozome:Sbicolor_v3.1.1'" },
+          "id":     { "type": "string", "description": "Source-native id (UniProt accession, Phytozome locus, etc.)" },
+          "og":     { "type": "string", "description": "OrthoFinder OG id it was placed into (e.g., 'OG0001234')" },
+          "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$", "description": "SHA-256 of the placed sequence (for incremental rebuild cache)" },
+          "pathway_role": { "type": "string", "description": "The abstract_enzyme / role from PlantSEED_Roles.json this protein backs" }
+        }
+      }
+    },
+
+    "delta_vs_previous": {
+      "type": "object",
+      "description": "Optional. Difference from the previous bundle version — populated by refbuild/stamp_version when a previous bundle is available on the same host.",
+      "properties": {
+        "previous_version":   { "type": "string" },
+        "proteins_added":     { "type": "integer" },
+        "proteins_dropped":   { "type": "integer" },
+        "proteins_resequenced": { "type": "integer" },
+        "ogs_added":          { "type": "integer" },
+        "ogs_dropped":        { "type": "integer" },
+        "role_kbase_ids_changed": { "type": "integer" }
+      }
+    }
+  }
+}

--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/refbuild/stamp_version.py
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/refbuild/stamp_version.py
@@ -1,0 +1,18 @@
+"""Finalize a bundle directory by writing its `manifest.json`.
+
+Composes the bundle version key (see manifest_schema.json) from:
+  - PlantSEED_Roles.json git SHA (from repo `git rev-parse HEAD -- Data/PlantSEED_v3/PlantSEED_Roles.json`)
+  - Phytozome release used for the baseline OrthoFinder run
+  - SHOOT DB build id (from create_shoot_db.py output)
+  - Tool versions: OrthoFinder, DIAMOND, MAFFT, SHOOT, EPA-ng, MSA
+
+Also records:
+  - SHA-256 of every file in the bundle (for verify())
+  - Bundle total size (for the per-tier refdata_gb_max check)
+  - List of curated non-Arabidopsis proteins added via SHOOT this run
+  - Delta vs previous bundle version (proteins added, dropped, resequenced)
+
+Consumed at annotation time by reference.load_manifest / reference.verify.
+
+Filled in at Phase 1.
+"""

--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/reference.py
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/reference.py
@@ -1,0 +1,28 @@
+"""Locate + verify the versioned refdata bundle at annotation time.
+
+A bundle directory contains everything the annotator needs to place a
+query genome's proteins into the enriched OrthoFinder families and
+propagate PlantSEED functions:
+
+    <BUNDLE_DIR>/
+      manifest.json
+      orthofinder_families_enriched/
+      shoot_db/
+      psi_matrices/
+      curation/
+      phylum_thresholds.json
+      uniprot_sequences.faa
+
+Filled in at Phase 1 (refbuild) and consumed at Phase 2 (algorithms).
+"""
+
+# Phase-2 stubs — implementations land as the algorithms come online.
+def load_manifest(bundle_dir=None):
+    raise NotImplementedError("Phase 1: implement manifest load + version pin")
+
+
+def verify(bundle_dir=None):
+    """Return (ok: bool, issues: [str]) for the bundle at `bundle_dir`.
+    Checks manifest present, hashes match, expected subdirs exist,
+    total size <= tier refdata_gb_max."""
+    raise NotImplementedError("Phase 1: implement bundle integrity check")

--- a/Scripts/PlantSEED_v3/Annotation/tests/README.md
+++ b/Scripts/PlantSEED_v3/Annotation/tests/README.md
@@ -1,0 +1,38 @@
+# plantseed_annotation — tests
+
+Run from this directory:
+
+```
+pytest
+```
+
+Or from anywhere:
+
+```
+pytest Scripts/PlantSEED_v3/Annotation/tests/
+```
+
+## Layout
+
+Mirrors `plantseed_curation/tests/`. Each test that mutates state uses
+the `tmp_bundle` fixture from `conftest.py`, which creates a temp bundle
+directory and sets `PLANTSEED_ANNOT_*` env vars so the library points at
+it (never at `/kb/data`).
+
+- `conftest.py` — shared fixtures (`tmp_bundle`, future genome fixtures).
+- `test_scaffold.py` — scaffold sanity: every module imports, tmp_bundle
+  fixture wires paths correctly, tier config exposes the expected values,
+  bundle manifest schema parses. This is the only test file the scaffold
+  ships with; every following Phase adds its own test file.
+
+## Planned test files (per phase)
+
+- `test_refbuild_*.py` (Phase 1) — bundle-build steps against a mini SHOOT
+  db + Arabidopsis-only OrthoFinder fixture
+- `test_algorithms_*.py` (Phase 2) — psi_refined, propagate, kmer
+- `test_dispatch.py` (Phase 2) — algorithm chain selection per tier / phylum
+- `test_cli_scripted.py` (Phase 3) — CLI end-to-end, scripted invocation
+- `tests/benchmarks/specialized_pathways/` (Phase 4) — publication benchmark
+  suite: dhurrin in *Zea mays*, taxol in *Taxus wallichiana*, homomethionine in
+  *Thlaspi arvense*, aliphatic glucosinolate in *Brassica rapa*, photosynthesis
+  in a monocot

--- a/Scripts/PlantSEED_v3/Annotation/tests/conftest.py
+++ b/Scripts/PlantSEED_v3/Annotation/tests/conftest.py
@@ -1,0 +1,48 @@
+"""Shared pytest fixtures for the plantseed_annotation test suite.
+
+Mirrors the pattern from plantseed_curation/tests/conftest.py: every test
+that mutates state gets a tmp bundle directory hierarchy plus
+PLANTSEED_ANNOT_* env vars pointing at it. The library re-reads those env
+vars via paths.refresh_from_env() so nothing touches a real /kb/data bundle.
+"""
+
+import os
+import sys
+
+import pytest
+
+
+# Make the package importable without installation.
+HERE = os.path.dirname(os.path.abspath(__file__))
+ANNOTATION_ROOT = os.path.dirname(HERE)
+sys.path.insert(0, ANNOTATION_ROOT)
+
+FIXTURES = os.path.join(HERE, "fixtures")
+
+
+@pytest.fixture
+def tmp_bundle(tmp_path, monkeypatch):
+    """Per-test tmp bundle root. Returns a dict with 'root', 'version', 'dir'.
+
+    The bundle 'dir' is empty on creation; individual tests populate the
+    manifest.json / subdirs they need. reference.verify() should be able to
+    diagnose the empty bundle as invalid — that's the negative-case test.
+    """
+    bundle_root = str(tmp_path / "bundle_root")
+    bundle_version = "vTEST"
+    bundle_dir = os.path.join(bundle_root, bundle_version)
+    os.makedirs(bundle_dir, exist_ok=True)
+
+    monkeypatch.setenv("PLANTSEED_ANNOT_BUNDLE_ROOT",    bundle_root)
+    monkeypatch.setenv("PLANTSEED_ANNOT_BUNDLE_VERSION", bundle_version)
+    monkeypatch.setenv("PLANTSEED_ANNOT_BUNDLE_DIR",     bundle_dir)
+
+    from plantseed_annotation import paths as p
+    p.refresh_from_env()
+    yield {"root": bundle_root, "version": bundle_version, "dir": bundle_dir}
+    p.refresh_from_env()
+
+
+# Placeholder for a shared standalone-genome fixture (a small Arabidopsis
+# minimal genome for round-trip tests). Wired up at Phase 1 when
+# genome_io.load exists.

--- a/Scripts/PlantSEED_v3/Annotation/tests/test_orthofinder_io.py
+++ b/Scripts/PlantSEED_v3/Annotation/tests/test_orthofinder_io.py
@@ -1,0 +1,146 @@
+"""orthofinder_io — Orthogroups.tsv / Orthologues.tsv / MSA parsers."""
+
+import os
+
+import pytest
+
+from plantseed_annotation.algorithms import orthofinder_io as oio
+
+
+@pytest.fixture
+def tiny_of_results(tmp_path):
+    """A minimal Orthofinder-Results-shaped directory tree."""
+    root = tmp_path / "Results_TEST"
+    (root / "Orthogroups").mkdir(parents=True)
+    (root / "MultipleSequenceAlignments").mkdir()
+    (root / "Orthologues" / "Orthologues_Sbicolor_v3.1.1").mkdir(parents=True)
+
+    (root / "Orthogroups" / "Orthogroups.tsv").write_text(
+        "Orthogroup\tAthaliana_TAIR10\tSbicolor_v3.1.1\n"
+        "OG0000001\tAT1G01050, AT1G01060\tSobic.001G000100\n"
+        "OG0000002\tAT2G00010\t\n"                               # ref-only
+        "OG0000003\t\tSobic.002G000100, Sobic.002G000200\n"      # query-only
+    )
+    (root / "Orthologues" / "Orthologues_Sbicolor_v3.1.1"
+        / "Sbicolor_v3.1.1__v__Athaliana_TAIR10.tsv").write_text(
+        "Orthogroup\tSbicolor_v3.1.1\tAthaliana_TAIR10\n"
+        "OG0000001\tSobic.001G000100\tAT1G01050, AT1G01060\n"
+    )
+    (root / "MultipleSequenceAlignments" / "OG0000001.fa").write_text(
+        ">AT1G01050\nMKKAA----KLPLL\n"
+        ">AT1G01060\nMKKAA----KLPLL\n"
+        ">Sobic.001G000100\nMKKATTKKKLPLL-\n"
+    )
+    return str(root)
+
+
+def test_load_orthogroups_shape(tiny_of_results):
+    ogs, species = oio.load_orthogroups(
+        os.path.join(tiny_of_results, "Orthogroups", "Orthogroups.tsv")
+    )
+    assert species == ["Athaliana_TAIR10", "Sbicolor_v3.1.1"]
+    assert set(ogs) == {"OG0000001", "OG0000002", "OG0000003"}
+    assert ogs["OG0000001"]["Athaliana_TAIR10"] == ["AT1G01050", "AT1G01060"]
+    assert ogs["OG0000001"]["Sbicolor_v3.1.1"] == ["Sobic.001G000100"]
+    assert ogs["OG0000002"]["Sbicolor_v3.1.1"] == []
+    assert ogs["OG0000003"]["Athaliana_TAIR10"] == []
+
+
+def test_species_gene_to_og_reverse_index(tiny_of_results):
+    ogs, _ = oio.load_orthogroups(
+        os.path.join(tiny_of_results, "Orthogroups", "Orthogroups.tsv")
+    )
+    idx = oio.species_gene_to_og_index(ogs)
+    assert idx[("Athaliana_TAIR10", "AT1G01050")] == "OG0000001"
+    assert idx[("Sbicolor_v3.1.1", "Sobic.002G000100")] == "OG0000003"
+    assert ("Athaliana_TAIR10", "AT9G99999") not in idx
+
+
+def test_orthologues_path_present_and_absent(tiny_of_results):
+    path = oio.orthologues_path(
+        tiny_of_results, "Sbicolor_v3.1.1", "Athaliana_TAIR10",
+    )
+    assert path is not None and path.endswith(
+        "Sbicolor_v3.1.1__v__Athaliana_TAIR10.tsv")
+    absent = oio.orthologues_path(
+        tiny_of_results, "Athaliana_TAIR10", "Sbicolor_v3.1.1",
+    )
+    assert absent is None
+
+
+def test_load_orthologues_symmetric(tiny_of_results):
+    path = oio.orthologues_path(
+        tiny_of_results, "Sbicolor_v3.1.1", "Athaliana_TAIR10",
+    )
+    q_to_r, r_to_q = oio.load_orthologues(path)
+    assert q_to_r["Sobic.001G000100"]["og"] == "OG0000001"
+    assert set(q_to_r["Sobic.001G000100"]["orthologs"]) == {"AT1G01050", "AT1G01060"}
+    assert set(r_to_q["AT1G01050"]["orthologs"]) == {"Sobic.001G000100"}
+
+
+def test_list_and_read_msa(tiny_of_results):
+    msas = list(oio.list_alignments(tiny_of_results))
+    assert msas == [("OG0000001",
+                     os.path.join(tiny_of_results, "MultipleSequenceAlignments",
+                                  "OG0000001.fa"))]
+    seqs = oio.read_msa(msas[0][1])
+    assert set(seqs) == {"AT1G01050", "AT1G01060", "Sobic.001G000100"}
+    assert seqs["AT1G01050"] == "MKKAA----KLPLL"
+
+
+# --- Species||prefix stripping + transcript_to_gene --------------------------
+def test_load_orthogroups_strips_species_prefix(tmp_path):
+    """Real OF results in Sam's repo carry a redundant '<species>||' prefix
+    on every cell entry (built from fasta headers like `Species_id||gene.N`).
+    The parser must strip it so callers can compare to curated gene ids."""
+    tsv = tmp_path / "Orthogroups.tsv"
+    tsv.write_text(
+        "Orthogroup\tAthaliana_TAIR10\tSbicolor_v3.1.1\n"
+        "OG0000001\tAthaliana_TAIR10||AT1G01050.1, Athaliana_TAIR10||AT1G01050.2\t"
+        "Sbicolor_v3.1.1||Sobic.001G000100.1\n"
+    )
+    ogs, _ = oio.load_orthogroups(str(tsv))
+    entry = ogs["OG0000001"]
+    assert entry["Athaliana_TAIR10"] == ["AT1G01050.1", "AT1G01050.2"]
+    assert entry["Sbicolor_v3.1.1"] == ["Sobic.001G000100.1"]
+
+
+def test_load_orthologues_strips_species_prefix(tmp_path):
+    """Same-shape prefix stripping applies to Orthologues/*__v__*.tsv."""
+    tsv = tmp_path / "Sbicolor_v3.1.1__v__Athaliana_TAIR10.tsv"
+    tsv.write_text(
+        "Orthogroup\tSbicolor_v3.1.1\tAthaliana_TAIR10\n"
+        "OG0000001\tSbicolor_v3.1.1||Sobic.001G000100.1\t"
+        "Athaliana_TAIR10||AT1G01050.1, Athaliana_TAIR10||AT1G01050.2\n"
+    )
+    q_to_r, r_to_q = oio.load_orthologues(str(tsv))
+    assert set(q_to_r) == {"Sobic.001G000100.1"}
+    assert set(q_to_r["Sobic.001G000100.1"]["orthologs"]) == {
+        "AT1G01050.1", "AT1G01050.2"}
+    assert set(r_to_q) == {"AT1G01050.1", "AT1G01050.2"}
+
+
+def test_read_msa_strips_any_species_prefix(tmp_path):
+    """MSA headers vary per-row so the reader strips '<anything>||' before
+    the gene id (unlike load_orthogroups, which uses the column header)."""
+    fasta = tmp_path / "OG.fa"
+    fasta.write_text(
+        ">Athaliana_TAIR10||AT1G01050.1\nMKK\n"
+        ">Sbicolor_v3.1.1||Sobic.001G000100.1\nMKK\n"
+        ">bare_gene\nMKK\n"
+    )
+    seqs = oio.read_msa(str(fasta))
+    assert set(seqs) == {"AT1G01050.1", "Sobic.001G000100.1", "bare_gene"}
+
+
+@pytest.mark.parametrize("tid, gene", [
+    ("AT1G01050.1",        "AT1G01050"),
+    ("AT1G01050.2",        "AT1G01050"),
+    ("Sobic.001G234700.1", "Sobic.001G234700"),
+    ("Potri.001G067600.1", "Potri.001G067600"),
+    ("AT1G01050",          "AT1G01050"),           # already gene-level
+    ("Sobic.001G234700",   "Sobic.001G234700"),    # last segment isn't digits
+    ("simple",             "simple"),              # no dots at all
+])
+def test_transcript_to_gene(tid, gene):
+    assert oio.transcript_to_gene(tid) == gene

--- a/Scripts/PlantSEED_v3/Annotation/tests/test_propagate.py
+++ b/Scripts/PlantSEED_v3/Annotation/tests/test_propagate.py
@@ -1,0 +1,147 @@
+"""propagate — curated-feature index and function-string composition."""
+
+import pytest
+
+from plantseed_annotation.algorithms import propagate
+
+
+# --- COMPARTMENT_MAPPING coverage --------------------------------------------
+def test_compartment_mapping_covers_every_real_localization_key():
+    """Every localization key used in current PlantSEED_Roles.json must map
+    to a template compartment name — otherwise those roles silently lose
+    their compartment tag and reconstruction defaults them to cytosol.
+
+    Enumerated from a full walk of dev's Data/PlantSEED_v3/PlantSEED_Roles.json:
+        c cd ce cm cv cx d de dy e g m mj n r v w x
+    """
+    real_keys = {"c", "cd", "ce", "cm", "cv", "cx", "d", "de", "dy",
+                 "e", "g", "m", "mj", "n", "r", "v", "w", "x"}
+    missing = real_keys - set(propagate.COMPARTMENT_MAPPING)
+    assert not missing, f"COMPARTMENT_MAPPING missing keys: {missing}"
+
+
+# --- build_curated_features --------------------------------------------------
+def _mini_role(role, features, localization):
+    """Compact factory for a fake role entry."""
+    return {
+        "role":          role,
+        "features":      features,
+        "localization":  localization,
+        "reactions":     ["rxn00001"],
+        "subsystems":    ["S"],
+        "include":       True,
+    }
+
+
+def test_build_curated_features_single_role_single_feature():
+    roles = [_mini_role(
+        "Alpha (EC 1.1.1.1)",
+        ["Athaliana_TAIR10||AT1G01050"],
+        {"c": {"Athaliana_TAIR10||AT1G01050": ["ref"]}},
+    )]
+    curated = propagate.build_curated_features(roles_data=roles)
+    key = ("Athaliana_TAIR10", "AT1G01050")
+    assert key in curated
+    entry = curated[key]
+    assert entry["roles"] == ["Alpha (EC 1.1.1.1)"]
+    assert entry["compartments"] == ["c"]
+    assert entry["function"] == "Alpha (EC 1.1.1.1) # cytosol"
+
+
+def test_build_curated_features_two_roles_merge_on_same_feature():
+    """A feature hit by two role entries collects both roles."""
+    roles = [
+        _mini_role("Beta", ["Athaliana_TAIR10||AT2G00010"],
+                   {"c": {"Athaliana_TAIR10||AT2G00010": []}}),
+        _mini_role("Alpha", ["Athaliana_TAIR10||AT2G00010"],
+                   {"c": {"Athaliana_TAIR10||AT2G00010": []}}),
+    ]
+    curated = propagate.build_curated_features(roles_data=roles)
+    entry = curated[("Athaliana_TAIR10", "AT2G00010")]
+    assert entry["roles"] == ["Alpha", "Beta"]     # sorted
+    assert entry["function"] == "Alpha / Beta # cytosol"
+
+
+def test_build_curated_features_multi_compartment_sorted():
+    """A feature in multiple compartments emits them in single-letter
+    sort order — matches fetch_plantseed_impl.fetch_features."""
+    roles = [_mini_role(
+        "Multi",
+        ["Athaliana_TAIR10||AT3G00010"],
+        {
+            "d": {"Athaliana_TAIR10||AT3G00010": []},
+            "c": {"Athaliana_TAIR10||AT3G00010": []},
+            "m": {"Athaliana_TAIR10||AT3G00010": []},
+        },
+    )]
+    curated = propagate.build_curated_features(roles_data=roles)
+    entry = curated[("Athaliana_TAIR10", "AT3G00010")]
+    assert entry["compartments"] == ["c", "d", "m"]
+    assert entry["function"] == "Multi # cytosol # plastid # mitochondria"
+
+
+def test_build_curated_features_dy_transport_maps_to_thylakoid():
+    """dy localization (thylakoid lumen transport) must appear as
+    'thylakoid' in the function string — this is the regression that
+    fetch_plantseed_impl and the current kb_orthofinder both had until
+    now."""
+    roles = [_mini_role(
+        "Thylakoider",
+        ["Athaliana_TAIR10||AT4G00010"],
+        {"dy": {"Athaliana_TAIR10||AT4G00010": []}},
+    )]
+    curated = propagate.build_curated_features(roles_data=roles)
+    entry = curated[("Athaliana_TAIR10", "AT4G00010")]
+    assert entry["function"] == "Thylakoider # thylakoid"
+
+
+def test_build_curated_features_ignores_features_not_in_localization():
+    """A feature listed on a role's features list but NOT under any
+    localization key gets no compartment tag."""
+    roles = [_mini_role(
+        "OrphanFeature",
+        ["Athaliana_TAIR10||AT5G00010"],
+        {},   # empty localization dict
+    )]
+    curated = propagate.build_curated_features(roles_data=roles)
+    entry = curated[("Athaliana_TAIR10", "AT5G00010")]
+    assert entry["compartments"] == []
+    assert entry["function"] == "OrphanFeature"
+
+
+def test_build_curated_features_parses_source_and_gene():
+    """Source prefix (Species_id||) is stripped into the key's first
+    element; a feature without ||-prefix produces (None, gene_id)."""
+    roles = [
+        _mini_role("X", ["Athaliana_TAIR10||AT1"], {"c": {"Athaliana_TAIR10||AT1": []}}),
+        _mini_role("Y", ["Uniprot||Q123"],         {"c": {"Uniprot||Q123": []}}),
+        _mini_role("Z", ["bare_gene"],             {"c": {"bare_gene": []}}),
+    ]
+    curated = propagate.build_curated_features(roles_data=roles)
+    assert ("Athaliana_TAIR10", "AT1") in curated
+    assert ("Uniprot", "Q123") in curated
+    assert (None, "bare_gene") in curated
+
+
+# --- curated_features_by_source_species --------------------------------------
+def test_group_by_source_species():
+    roles = [
+        _mini_role("A", ["Athaliana_TAIR10||AT1"], {"c": {"Athaliana_TAIR10||AT1": []}}),
+        _mini_role("B", ["Sbicolor_v3.1.1||Sob1"], {"c": {"Sbicolor_v3.1.1||Sob1": []}}),
+    ]
+    curated = propagate.build_curated_features(roles_data=roles)
+    by_spp = propagate.curated_features_by_source_species(curated)
+    assert set(by_spp) == {"Athaliana_TAIR10", "Sbicolor_v3.1.1"}
+    assert set(by_spp["Athaliana_TAIR10"]) == {"AT1"}
+    assert set(by_spp["Sbicolor_v3.1.1"]) == {"Sob1"}
+
+
+# --- function_for_ortholog ---------------------------------------------------
+def test_function_for_ortholog_hit_and_miss():
+    curated = {
+        ("Athaliana_TAIR10", "AT1"): {"function": "Alpha # cytosol"},
+    }
+    assert propagate.function_for_ortholog(
+        ("Athaliana_TAIR10", "AT1"), curated) == "Alpha # cytosol"
+    assert propagate.function_for_ortholog(
+        ("Athaliana_TAIR10", "MISSING"), curated) is None

--- a/Scripts/PlantSEED_v3/Annotation/tests/test_psi.py
+++ b/Scripts/PlantSEED_v3/Annotation/tests/test_psi.py
@@ -1,0 +1,116 @@
+"""psi — pairwise sequence identity computation + cache."""
+
+import os
+
+import pytest
+
+from plantseed_annotation.algorithms import psi
+
+
+def test_compute_psi_for_msa_identical_pair():
+    """Two identical, no-gap sequences → PSI = 1.0."""
+    rows = psi.compute_psi_for_msa({"a": "MKKAA", "b": "MKKAA"})
+    assert len(rows) == 1
+    g1, g2, id1, id2, p = rows[0]
+    assert (g1, g2) == ("a", "b")
+    assert id1 == id2 == p == 1.0
+
+
+def test_compute_psi_for_msa_completely_different():
+    """No matching positions → PSI = 0.0."""
+    rows = psi.compute_psi_for_msa({"a": "MKKAA", "b": "PPPPP"})
+    _, _, id1, id2, p = rows[0]
+    assert id1 == id2 == p == 0.0
+
+
+def test_compute_psi_for_msa_gaps_shrink_denominator():
+    """A gap-inserted position doesn't count toward matches OR toward the
+    denominator (which uses the *unaligned* length of each sequence)."""
+    # a: 5 non-gap chars, b: 5 non-gap chars, 5 matches (excluding the gap)
+    rows = psi.compute_psi_for_msa({"a": "MKKAA-", "b": "MKKAA-"})
+    _, _, id1, id2, p = rows[0]
+    assert id1 == id2 == p == 1.0
+
+    # a: 6 non-gap chars, b: 5 non-gap chars (a has a residue where b has a gap)
+    rows = psi.compute_psi_for_msa({"a": "MKKAAA", "b": "MKKAA-"})
+    _, _, id1, id2, p = rows[0]
+    # 5 matches (positions 0-4); pos 5 skipped (gap on b)
+    # id1 = 5/6, id2 = 5/5 = 1.0
+    assert id1 == pytest.approx(5 / 6)
+    assert id2 == 1.0
+    assert p == pytest.approx((5 / 6 + 1.0) / 2)
+
+
+def test_compute_psi_for_msa_pair_ordering_is_alphabetical():
+    """Rows are sorted so the pair (features[i], features[j]) always has
+    features[i] < features[j]. Callers depend on this for cache lookup."""
+    rows = psi.compute_psi_for_msa({"z": "MK", "a": "MK", "m": "MK"})
+    pairs = [(r[0], r[1]) for r in rows]
+    assert pairs == [("a", "m"), ("a", "z"), ("m", "z")]
+
+
+def test_psi_cache_roundtrip(tmp_path):
+    """write_cache_file → read_cache_file yields the same rows (with the
+    2-decimal rounding the file format imposes)."""
+    rows = [
+        ("a", "b", 0.75, 0.80, 0.775),
+        ("a", "c", 0.55, 0.60, 0.575),
+    ]
+    p = tmp_path / "OG0000001.txt"
+    psi.write_cache_file(str(p), "OG0000001", rows)
+    loaded = psi.read_cache_file(str(p))
+    assert len(loaded) == 2
+    for orig, back in zip(rows, loaded):
+        assert orig[0] == back[0] and orig[1] == back[1]
+        # 2-decimal rounding
+        assert round(orig[2], 2) == round(back[2], 2)
+        assert round(orig[3], 2) == round(back[3], 2)
+        assert round(orig[4], 2) == round(back[4], 2)
+
+
+def test_ensure_psi_cache_computes_then_caches(tmp_path):
+    """First call computes; second call finds the cache and skips."""
+    of = tmp_path / "Results"
+    (of / "MultipleSequenceAlignments").mkdir(parents=True)
+    (of / "MultipleSequenceAlignments" / "OG0000001.fa").write_text(
+        ">a\nMKKAA\n>b\nMKKAA\n"
+    )
+    cache1, stats1 = psi.ensure_psi_cache(str(of), n_workers=1, log=lambda m: None)
+    assert os.path.isfile(os.path.join(cache1, "OG0000001.txt"))
+    assert stats1.get("OG0000001") == 1  # 1 pair
+
+    # Second call: cache hit
+    cache2, stats2 = psi.ensure_psi_cache(str(of), n_workers=1, log=lambda m: None)
+    assert cache1 == cache2
+    # Cache hit shows up as 0 in the returned stats (nothing recomputed)
+    assert stats2.get("OG0000001") == 0
+
+
+def test_ensure_psi_cache_restricts_by_ogs(tmp_path):
+    """Passing `ogs=` restricts computation to the requested OGs; others are
+    ignored."""
+    of = tmp_path / "Results"
+    (of / "MultipleSequenceAlignments").mkdir(parents=True)
+    for og in ("OG0000001", "OG0000002"):
+        (of / "MultipleSequenceAlignments" / (og + ".fa")).write_text(
+            ">a\nMK\n>b\nMK\n"
+        )
+    cache_dir, stats = psi.ensure_psi_cache(
+        str(of), ogs={"OG0000001"}, n_workers=1, log=lambda m: None,
+    )
+    assert os.path.isfile(os.path.join(cache_dir, "OG0000001.txt"))
+    assert not os.path.isfile(os.path.join(cache_dir, "OG0000002.txt"))
+
+
+def test_psi_lookup_order_independent(tmp_path):
+    """Lookup by (a, b) or (b, a) returns the same PSI."""
+    of = tmp_path / "Results"
+    (of / "MultipleSequenceAlignments").mkdir(parents=True)
+    (of / "MultipleSequenceAlignments" / "OG0000001.fa").write_text(
+        ">a\nMKKAA\n>b\nMKKAA\n"
+    )
+    cache_dir, _ = psi.ensure_psi_cache(str(of), n_workers=1, log=lambda m: None)
+    loaded = psi.load_psi_for_ogs(cache_dir, {"OG0000001"})
+    assert psi.psi_lookup(loaded, "OG0000001", "a", "b") == 1.0
+    assert psi.psi_lookup(loaded, "OG0000001", "b", "a") == 1.0
+    assert psi.psi_lookup(loaded, "OG0000001", "a", "missing") is None

--- a/Scripts/PlantSEED_v3/Annotation/tests/test_psi_refined.py
+++ b/Scripts/PlantSEED_v3/Annotation/tests/test_psi_refined.py
@@ -1,0 +1,359 @@
+"""psi_refined — ortholog resolution + tie-break rules ported from
+kb_orthofinderImpl.propagate_annotation."""
+
+import pytest
+
+from plantseed_annotation.algorithms import psi_refined as pr
+
+
+CURATED = {
+    "AT1": {"function": "Alpha (EC 1.1.1.1) # cytosol"},
+    "AT2": {"function": "Beta (EC 2.2.2.2) # plastid"},
+    "AT3": {"function": "Alpha (EC 1.1.1.1) # cytosol"},   # same fn as AT1
+    "AT4": {"function": "Alpha (EC 1.1.1.1) # cytosol # plastid"},  # substring-superset of AT1
+    "AT_UNANN": {"function": "Unannotated"},
+}
+
+
+def _psi_of(mapping):
+    """Turn a dict of {ref_gene: psi} into the psi_lookup_fn shape used
+    by annotate_query_gene."""
+    def _lookup(query, ref, _m=mapping):
+        return _m.get(ref)
+    return _lookup
+
+
+def test_annotate_no_orthologs():
+    r = pr.annotate_query_gene(
+        "Q1", [], _psi_of({}), 0.5, CURATED, "Athaliana_TAIR10",
+    )
+    assert r["status"] == "NO_ORTHOLOG"
+    assert r["function"] is None
+
+
+def test_annotate_all_below_threshold():
+    r = pr.annotate_query_gene(
+        "Q1", ["AT1", "AT2"], _psi_of({"AT1": 0.30, "AT2": 0.40}),
+        threshold=0.60, curated_features_for_ref=CURATED, ref_species="Athaliana_TAIR10",
+    )
+    assert r["status"] == "LT_THRESHOLD"
+    assert r["psi"] == 0.40
+    assert r["function"] is None
+
+
+def test_annotate_unique_top_ref():
+    r = pr.annotate_query_gene(
+        "Q1", ["AT1", "AT2"], _psi_of({"AT1": 0.85, "AT2": 0.70}),
+        threshold=0.60, curated_features_for_ref=CURATED, ref_species="Athaliana_TAIR10",
+    )
+    assert r["status"] == "ANNOTATED"
+    assert r["top_ortholog"] == ("Athaliana_TAIR10", "AT1")
+    assert r["function"] == "Alpha (EC 1.1.1.1) # cytosol"
+    assert r["psi"] == 0.85
+
+
+def test_tie_break_same_function_arbitrary_pick():
+    """Two refs tied at top PSI with the same function → pick either
+    (deterministically the alphabetical first, per the port)."""
+    r = pr.annotate_query_gene(
+        "Q1", ["AT1", "AT3"], _psi_of({"AT1": 0.80, "AT3": 0.80}),
+        threshold=0.60, curated_features_for_ref=CURATED, ref_species="Athaliana_TAIR10",
+    )
+    assert r["status"] == "ANNOTATED"
+    assert r["function"] == "Alpha (EC 1.1.1.1) # cytosol"
+
+
+def test_tie_break_unannotated_vs_annotated_picks_annotated():
+    r = pr.annotate_query_gene(
+        "Q1", ["AT_UNANN", "AT1"], _psi_of({"AT_UNANN": 0.80, "AT1": 0.80}),
+        threshold=0.60, curated_features_for_ref=CURATED, ref_species="Athaliana_TAIR10",
+    )
+    assert r["status"] == "ANNOTATED"
+    assert r["top_ortholog"] == ("Athaliana_TAIR10", "AT1")
+    assert r["function"] == "Alpha (EC 1.1.1.1) # cytosol"
+
+
+def test_tie_break_substring_variant_picks_either():
+    """AT1's function is a substring of AT4's (compartmentalization variant);
+    the ported rule picks one arbitrarily rather than ambiguating."""
+    r = pr.annotate_query_gene(
+        "Q1", ["AT1", "AT4"], _psi_of({"AT1": 0.80, "AT4": 0.80}),
+        threshold=0.60, curated_features_for_ref=CURATED, ref_species="Athaliana_TAIR10",
+    )
+    assert r["status"] == "ANNOTATED"
+
+
+def test_tie_break_two_distinct_functions_ambiguous():
+    """Two refs tied at top PSI with two DIFFERENT non-substring functions
+    → status AMB_HIT, no propagation."""
+    r = pr.annotate_query_gene(
+        "Q1", ["AT1", "AT2"], _psi_of({"AT1": 0.80, "AT2": 0.80}),
+        threshold=0.60, curated_features_for_ref=CURATED, ref_species="Athaliana_TAIR10",
+    )
+    assert r["status"] == "AMB_HIT"
+    assert r["function"] is None
+
+
+def test_tie_break_three_distinct_functions_ambiguous():
+    """More than two distinct functions → always ambiguous."""
+    curated = dict(CURATED)
+    curated["AT5"] = {"function": "Gamma"}
+    r = pr.annotate_query_gene(
+        "Q1", ["AT1", "AT2", "AT5"],
+        _psi_of({"AT1": 0.80, "AT2": 0.80, "AT5": 0.80}),
+        threshold=0.60, curated_features_for_ref=curated,
+        ref_species="Athaliana_TAIR10",
+    )
+    assert r["status"] == "AMB_HIT"
+
+
+def test_annotate_species_end_to_end_shape():
+    """annotate_species walks OGs, classifies pairs, and emits one entry per
+    query GENE (aggregating transcripts) with a curated candidate."""
+    orth = {
+        "Q1.1": {"og": "OG0000001", "orthologs": ["AT1"]},   # OF ortholog
+        "Q3.1": {"og": "OG0000003", "orthologs": ["AT1", "AT3"]},   # same fn → OK
+    }
+    ogs = {
+        "OG0000001": {"Sbicolor_v3.1.1": ["Q1.1"],
+                      "Athaliana_TAIR10": ["AT1", "AT2"]},
+        "OG0000002": {"Sbicolor_v3.1.1": ["Q2.1"],
+                      "Athaliana_TAIR10": ["AT_UNCURATED"]},
+        "OG0000003": {"Sbicolor_v3.1.1": ["Q3.1"],
+                      "Athaliana_TAIR10": ["AT1", "AT3"]},
+    }
+    psi_by_og = {
+        "OG0000001": {("AT1", "Q1.1"): 0.80, ("AT2", "Q1.1"): 0.65},
+        "OG0000002": {("AT_UNCURATED", "Q2.1"): 0.70},
+        "OG0000003": {("AT1", "Q3.1"): 0.75, ("AT3", "Q3.1"): 0.75},
+    }
+    sp_to_og = {("Sbicolor_v3.1.1", "Q1.1"): "OG0000001",
+                ("Sbicolor_v3.1.1", "Q2.1"): "OG0000002",
+                ("Sbicolor_v3.1.1", "Q3.1"): "OG0000003",
+                ("Athaliana_TAIR10", "AT1"): "OG0000001",
+                ("Athaliana_TAIR10", "AT2"): "OG0000001",
+                ("Athaliana_TAIR10", "AT_UNCURATED"): "OG0000002",
+                ("Athaliana_TAIR10", "AT3"): "OG0000003"}
+    annotations, stats, pair_stats = pr.annotate_species(
+        "Sbicolor_v3.1.1", "Athaliana_TAIR10", orth,
+        ogs, psi_by_og, sp_to_og, CURATED, threshold=0.60,
+    )
+    # Q1, Q2, Q3 all appear as candidates in ogs. Q2's AT_UNCURATED
+    # ortholog is filtered out at the curation gate, so Q2 gets status
+    # NO_ORTHOLOG (candidate seen but no curated ref survives).
+    assert set(annotations) == {"Q1", "Q2", "Q3"}
+    assert annotations["Q1"]["status"] == "ANNOTATED"
+    assert annotations["Q1"]["top_ortholog"] == ("Athaliana_TAIR10", "AT1")
+    assert annotations["Q3"]["status"] == "ANNOTATED"
+    assert annotations["Q2"]["status"] == "NO_ORTHOLOG"
+    assert stats["ANNOTATED"] == 2
+    assert stats["NO_ORTHOLOG"] == 1
+
+
+def test_annotate_species_admits_paralog_above_baseline():
+    """The Processing_v2 core: a paralog (not called ortholog by OF) whose
+    PSI exceeds the per-OG baseline is admitted as an annotation candidate.
+    This is precisely what the naive OF-orthologs-only path misses."""
+    # OG has two Ath curated genes (AT1, AT2) and one query gene (Q1)
+    # OF only calls AT1↔Q1 as ortholog. AT2 is a paralog in the same OG.
+    #   Baseline PSI = mean over OF orthologs = PSI(AT1, Q1.1) = 0.80
+    #   PSI(AT2, Q1.1) = 0.85 > 0.80  → admit AT2 as PAM
+    #   Since AT2 has higher PSI, it becomes the top candidate.
+    orth = {
+        "Q1.1": {"og": "OG0000001", "orthologs": ["AT1"]},   # only AT1 called ortholog
+    }
+    ogs = {
+        "OG0000001": {"Sbicolor_v3.1.1": ["Q1.1"],
+                      "Athaliana_TAIR10": ["AT1", "AT2"]},
+    }
+    psi_by_og = {
+        "OG0000001": {
+            ("AT1", "Q1.1"): 0.80,   # OF ortholog → sets baseline = 0.80
+            ("AT2", "Q1.1"): 0.85,   # paralog, above baseline → admit as PAM
+        },
+    }
+    sp_to_og = {("Sbicolor_v3.1.1", "Q1.1"): "OG0000001",
+                ("Athaliana_TAIR10", "AT1"): "OG0000001",
+                ("Athaliana_TAIR10", "AT2"): "OG0000001"}
+    curated = {
+        "AT1": {"function": "Alpha # cytosol"},
+        "AT2": {"function": "Beta # plastid"},
+    }
+    annotations, stats, pair_stats = pr.annotate_species(
+        "Sbicolor_v3.1.1", "Athaliana_TAIR10", orth,
+        ogs, psi_by_og, sp_to_og, curated, threshold=0.60,
+    )
+    # Both AT1 (O, 0.80) and AT2 (PAM, 0.85) are candidates; AT2 has strictly
+    # higher PSI so wins the top slot outright — no tie, so no AMB_HIT.
+    # This is the whole point: paralog admission changes the top ortholog
+    # from AT1 (what naive OF gave us) to AT2 (what PSI actually supports).
+    assert pair_stats["O"] == 1
+    assert pair_stats["PAM"] == 1
+    assert annotations["Q1"]["status"] == "ANNOTATED"
+    assert annotations["Q1"]["top_ortholog"] == ("Athaliana_TAIR10", "AT2")
+    assert annotations["Q1"]["function"] == "Beta # plastid"
+    assert annotations["Q1"]["psi"] == 0.85
+
+    # Compare against admit_paralogs=False: only AT1 is a candidate → AT1 wins,
+    # a different (potentially wrong) annotation is propagated.
+    ann_naive, _, pair_stats_naive = pr.annotate_species(
+        "Sbicolor_v3.1.1", "Athaliana_TAIR10", orth,
+        ogs, psi_by_og, sp_to_og, curated, threshold=0.60,
+        admit_paralogs=False,
+    )
+    assert pair_stats_naive.get("PAM", 0) == 0
+    assert ann_naive["Q1"]["status"] == "ANNOTATED"
+    assert ann_naive["Q1"]["top_ortholog"] == ("Athaliana_TAIR10", "AT1")
+    assert ann_naive["Q1"]["function"] == "Alpha # cytosol"
+
+
+def test_annotate_species_paralog_rejected_below_baseline():
+    """A paralog below the baseline is dropped (PRM), so if OF called no
+    ortholog for the query, the paralog can't propagate."""
+    orth = {
+        "Q1.1": {"og": "OG0000001", "orthologs": ["AT2"]},   # OF ortholog: only AT2
+    }
+    ogs = {
+        "OG0000001": {"Sbicolor_v3.1.1": ["Q1.1"],
+                      "Athaliana_TAIR10": ["AT1", "AT2"]},
+    }
+    psi_by_og = {
+        "OG0000001": {
+            ("AT2", "Q1.1"): 0.80,   # OF ortholog → baseline = 0.80
+            ("AT1", "Q1.1"): 0.65,   # paralog, BELOW baseline → PRM (reject)
+        },
+    }
+    sp_to_og = {("Sbicolor_v3.1.1", "Q1.1"): "OG0000001",
+                ("Athaliana_TAIR10", "AT1"): "OG0000001",
+                ("Athaliana_TAIR10", "AT2"): "OG0000001"}
+    curated = {
+        "AT1": {"function": "Alpha # cytosol"},
+        "AT2": {"function": "Beta # plastid"},
+    }
+    annotations, stats, pair_stats = pr.annotate_species(
+        "Sbicolor_v3.1.1", "Athaliana_TAIR10", orth,
+        ogs, psi_by_og, sp_to_og, curated, threshold=0.60,
+    )
+    assert pair_stats.get("O", 0) == 1
+    assert pair_stats.get("PAM", 0) == 0
+    assert annotations["Q1"]["top_ortholog"] == ("Athaliana_TAIR10", "AT2")
+
+
+def test_annotate_species_fallback_baseline_pah():
+    """No OF orthologs in an OG for (query, ref) → fall back to 0.5.
+    Paralogs above 0.5 get tagged PAH and accepted."""
+    orth = {}   # No OF orthologs in the whole run
+    ogs = {
+        "OG0000001": {"Sbicolor_v3.1.1": ["Q1.1"],
+                      "Athaliana_TAIR10": ["AT1"]},
+    }
+    psi_by_og = {
+        "OG0000001": {("AT1", "Q1.1"): 0.75},  # no OF ortholog, > 0.5 fallback
+    }
+    sp_to_og = {("Sbicolor_v3.1.1", "Q1.1"): "OG0000001",
+                ("Athaliana_TAIR10", "AT1"): "OG0000001"}
+    curated = {"AT1": {"function": "Alpha # cytosol"}}
+    annotations, stats, pair_stats = pr.annotate_species(
+        "Sbicolor_v3.1.1", "Athaliana_TAIR10", orth,
+        ogs, psi_by_og, sp_to_og, curated, threshold=0.60,
+    )
+    assert pair_stats.get("PAH", 0) == 1
+    assert pair_stats.get("O", 0) == 0
+    assert annotations["Q1"]["status"] == "ANNOTATED"
+
+
+def test_annotate_species_aggregates_multi_transcript_max_psi():
+    """Two transcripts of the same query gene, each with an ortholog to the
+    same ref gene. PSI(query_gene, ref_gene) = MAX over the transcript pairs."""
+    orth = {
+        "Q1.1": {"og": "OG0000001", "orthologs": ["AT1.1"]},
+        "Q1.2": {"og": "OG0000001", "orthologs": ["AT1.2"]},
+    }
+    ogs = {"OG0000001": {"Sbicolor_v3.1.1": ["Q1.1", "Q1.2"],
+                          "Athaliana_TAIR10": ["AT1.1", "AT1.2"]}}
+    psi_by_og = {
+        "OG0000001": {
+            ("AT1.1", "Q1.1"): 0.65,
+            ("AT1.2", "Q1.2"): 0.80,   # this one wins
+            ("AT1.1", "Q1.2"): 0.55,
+            ("AT1.2", "Q1.1"): 0.60,
+        },
+    }
+    sp_to_og = {
+        ("Sbicolor_v3.1.1", "Q1.1"): "OG0000001",
+        ("Sbicolor_v3.1.1", "Q1.2"): "OG0000001",
+        ("Athaliana_TAIR10", "AT1.1"): "OG0000001",
+        ("Athaliana_TAIR10", "AT1.2"): "OG0000001",
+    }
+    curated = {"AT1": {"function": "Alpha # cytosol"}}
+    annotations, stats, _ = pr.annotate_species(
+        "Sbicolor_v3.1.1", "Athaliana_TAIR10", orth,
+        ogs, psi_by_og, sp_to_og, curated, threshold=0.60,
+    )
+    assert set(annotations) == {"Q1"}
+    assert annotations["Q1"]["status"] == "ANNOTATED"
+    assert annotations["Q1"]["psi"] == 0.80
+    assert annotations["Q1"]["top_ortholog"] == ("Athaliana_TAIR10", "AT1")
+
+
+# --- compute_og_baselines + classify_og_pairs (Processing_v2 primitives) ------
+def test_compute_og_baselines_mean_over_of_orthologs():
+    """Baseline for an OG = arithmetic mean over OF-called ortholog PSI values
+    between the query and ref species in that OG."""
+    orth = {
+        "Q1.1": {"og": "OG0000001", "orthologs": ["AT1"]},
+        "Q2.1": {"og": "OG0000001", "orthologs": ["AT2"]},
+    }
+    psi_by_og = {"OG0000001": {
+        ("AT1", "Q1.1"): 0.80,
+        ("AT2", "Q2.1"): 0.60,
+        # Not an OF ortholog — should NOT contribute to the baseline
+        ("AT1", "Q2.1"): 0.90,
+    }}
+    sp_to_og = {}
+    b = pr.compute_og_baselines(orth, psi_by_og, sp_to_og,
+                                 "Sbicolor_v3.1.1", "Athaliana_TAIR10")
+    assert b["OG0000001"] == (0.80 + 0.60) / 2   # 0.70
+
+
+def test_compute_og_baselines_missing_when_no_of_orthologs():
+    """OGs with no OF ortholog pair (for this query↔ref) don't appear in
+    the baseline dict."""
+    orth = {}
+    psi_by_og = {"OG0000001": {("AT1", "Q1.1"): 0.90}}
+    b = pr.compute_og_baselines(orth, psi_by_og, {},
+                                 "Sbicolor_v3.1.1", "Athaliana_TAIR10")
+    assert "OG0000001" not in b
+
+
+def test_classify_og_pairs_tag_matrix():
+    """Every case: O (OF ortholog), PAM (paralog above mean), PRM (below),
+    PAH (paralog above fallback when no baseline), PRH (below fallback)."""
+    q_tr = ["Q1"]
+    r_tr = ["AT1", "AT2", "AT3"]
+    of_pairs = {frozenset({"Q1", "AT1"})}
+    psi_map = {
+        pr._pair_key("Q1", "AT1"): 0.80,   # OF ortholog → O
+        pr._pair_key("Q1", "AT2"): 0.85,   # paralog above 0.80 → PAM
+        pr._pair_key("Q1", "AT3"): 0.50,   # paralog below 0.80 → PRM (rejected, not returned)
+    }
+    accepted = pr.classify_og_pairs(
+        "OG_", q_tr, r_tr, of_pairs, psi_map, baseline=0.80,
+    )
+    tags = {(a, b, t) for (a, b, _p, t) in accepted}
+    assert ("Q1", "AT1", "O") in tags
+    assert ("Q1", "AT2", "PAM") in tags
+    # AT3 rejected → not in the returned list
+    assert not any(t == "AT3" for (a, b, _p, _tag) in accepted for t in (a, b))
+
+    # No baseline available → use fallback 0.5.
+    of_pairs_none = set()
+    accepted2 = pr.classify_og_pairs(
+        "OG_", q_tr, r_tr, of_pairs_none, psi_map,
+        baseline=None, fallback_baseline=0.5,
+    )
+    tags2 = {(a, b, t) for (a, b, _p, t) in accepted2}
+    assert ("Q1", "AT1", "PAH") in tags2
+    assert ("Q1", "AT2", "PAH") in tags2
+    # AT3 at exactly 0.5 → PRH, rejected (strict > comparison, matches Processing_v2)
+    assert not any(a == "Q1" and b == "AT3" for (a, b, _p, _t) in accepted2)

--- a/Scripts/PlantSEED_v3/Annotation/tests/test_scaffold.py
+++ b/Scripts/PlantSEED_v3/Annotation/tests/test_scaffold.py
@@ -12,14 +12,20 @@ import pytest
 
 
 def test_package_imports_cleanly():
-    """A totally empty scaffold at least imports and exposes the public
-    modules under __init__."""
+    """Every module in the package tree imports without side effects."""
     import plantseed_annotation
     for sub in ("paths", "config", "reference", "dispatch", "genome_io",
                 "emit", "cli"):
         assert hasattr(plantseed_annotation, sub) or __import__(
             f"plantseed_annotation.{sub}", fromlist=[sub]
         )
+
+
+def test_public_api_exports_are_all_importable():
+    """Every name in __all__ actually resolves."""
+    import plantseed_annotation as psa
+    for name in psa.__all__:
+        assert hasattr(psa, name), f"__all__ names {name!r} but attribute is missing"
 
 
 def test_algorithms_and_refbuild_import():

--- a/Scripts/PlantSEED_v3/Annotation/tests/test_scaffold.py
+++ b/Scripts/PlantSEED_v3/Annotation/tests/test_scaffold.py
@@ -1,0 +1,66 @@
+"""Sanity tests for the scaffold — every module imports cleanly and the
+paths + config surfaces behave the way conftest fixtures expect.
+
+Real behavior tests land as each algorithm / refbuild step comes online in
+Phases 1-3.
+"""
+
+import json
+import os
+
+import pytest
+
+
+def test_package_imports_cleanly():
+    """A totally empty scaffold at least imports and exposes the public
+    modules under __init__."""
+    import plantseed_annotation
+    for sub in ("paths", "config", "reference", "dispatch", "genome_io",
+                "emit", "cli"):
+        assert hasattr(plantseed_annotation, sub) or __import__(
+            f"plantseed_annotation.{sub}", fromlist=[sub]
+        )
+
+
+def test_algorithms_and_refbuild_import():
+    for m in ("place_query", "psi_refined", "propagate", "kmer"):
+        __import__(f"plantseed_annotation.algorithms.{m}", fromlist=[m])
+    for m in ("build_orthofinder_db", "build_shoot_db",
+              "enrich_with_curated_proteins", "build_psi_matrices",
+              "stamp_version"):
+        __import__(f"plantseed_annotation.refbuild.{m}", fromlist=[m])
+
+
+def test_tmp_bundle_fixture_sets_env(tmp_bundle):
+    """Confirm the fixture wired the PLANTSEED_ANNOT_* env vars and that
+    paths refreshed to point at the tmp bundle, not /kb/data."""
+    from plantseed_annotation import paths as p
+    assert p.BUNDLE_ROOT == tmp_bundle["root"]
+    assert p.BUNDLE_VERSION == tmp_bundle["version"]
+    assert p.BUNDLE_DIR == tmp_bundle["dir"]
+    assert os.path.isdir(p.BUNDLE_DIR)
+
+
+def test_config_tier_names():
+    from plantseed_annotation import config
+    assert set(config.BY_NAME) == {"kbase", "poplar", "local"}
+    kb = config.get("kbase")
+    assert kb.ram_gb_max == 22
+    assert kb.cpu_max == 2
+    assert kb.refdata_gb_max == 10
+    with pytest.raises(ValueError):
+        config.get("nope")
+
+
+def test_manifest_schema_is_valid_json():
+    schema_path = os.path.join(
+        os.path.dirname(__file__), "..", "plantseed_annotation",
+        "refbuild", "manifest_schema.json",
+    )
+    with open(schema_path) as f:
+        schema = json.load(f)
+    assert schema["title"].startswith("plantseed_annotation")
+    assert schema["properties"]["schema_version"]["const"] == 1
+    for req in ("bundle_version", "sources", "tool_versions", "contents",
+                "totals", "curated_non_arabidopsis"):
+        assert req in schema["required"]


### PR DESCRIPTION
## Summary

Adds the `plantseed_annotation` Python package — a standalone
annotator + reconstructor pipeline that takes an OrthoFinder-2 results
directory plus `PlantSEED_Roles.json` and produces annotated genome
JSONs (`plantseed-annotate`) and FBAModel JSONs (`plantseed-reconstruct`)
in the shape `reconstruct_app_impl.py` already consumes. Ports the
`Identify_Functional_Homologs.py` / `Process_Functional_Homologs.py`
algorithm out of `~/Seq_Home/PlantSEED_Processing_v2/` into a
library-form callable, with the "O + PAM + PAH" acceptance rule and
the `kb_orthofinder`-style tie-break.

Preprint reconstructions built with this pipeline for Athaliana +
Sorghum + Populus are pinned in
`/scratch/seaver/Claude_Projects/plantseed-v3/preprint_reconstructions_260806/`
(not in this PR — output artefacts).

## What's here

8 commits, each self-contained:

- `2d9fa24` **Scaffold `plantseed_annotation` package + tests + bundle manifest schema**
  Empty package tree under `Scripts/PlantSEED_v3/Annotation/`
  mirroring the `Curation/plantseed_curation/` layout — modules with
  purposeful docstrings, JSON-Schema draft-2020-12 bundle manifest,
  pytest skeleton.
- `08a86e0` **Extend `plantseed_annotation.paths` with compartments + species phyla + thresholds**
  `COMPARTMENTS_FILE`, `SPECIES_PHYLA_FILE`,
  `PHYLUM_THRESHOLDS_DEFAULT` (Eudicot 0.60, Monocot 0.55, Basal 0.30 —
  matching `KBase/Annotate_Single_Genome_in_KBase.pl`).
- `3cd3a8a` **Add `algorithms.orthofinder_io` — Orthogroups / Orthologues / MSA readers**
  Parsers with `<species>||` prefix stripping and `transcript_to_gene`
  (`.<digits>` suffix removal that correctly leaves `Sobic.001G234700`
  alone). 13 tests.
- `e38419d` **Add `algorithms.psi` — pairwise sequence identity computation + disk cache**
  Ported from `Calculate_Pairwise_Sequence_Identity.py`; cache file
  format matches Processing_v2's verbatim. `mp.Pool`-parallel with
  `ogs=` restriction to skip the ~30 200 OGs that don't touch curated
  ref-species genes. 8 tests.
- `cb80629` **Add `algorithms.propagate` — PlantSEED-Roles-derived curated feature index**
  Ports `fetch_features()` out of `kb_orthofinder`. `COMPARTMENT_MAPPING`
  now includes `dy → thylakoid` (43 role occurrences on dev — see
  companion PR `add-dy-compartment-260806`). 11 tests, including a
  regression that enumerates every real-world localization key and
  demands each has a mapping.
- `8db90a5` **Add `algorithms.psi_refined` — Processing_v2 O+PAM+PAH classifier + tie-break**
  Full algorithm port with the correct threshold semantics: the
  per-phylum PSI floor gates paralogs only. **OF-called orthologs
  propagate their function regardless of PSI** — matches Processing_v2
  (which applies no floor at all) and recovers Sorghum-Ath ortholog
  coverage at PSI 0.50–0.55. 15 tests.
- `fc56c60` **Add `plantseed-annotate` CLI + `genome_io` writer**
  Wires everything into a runnable CLI. Self-annotation path when
  `--query-species == --ref-species` (round-trip validation baseline).
  Phylum auto-detection from `Species_Phyla.txt`.
- `8c94a98` **Add `plantseed-reconstruct` CLI; wire full public API + update scaffold test**
  Thin argparse wrapper around
  `Scripts/PlantSEED_v3/Model/reconstruct_app_impl.py` (loaded by path
  since it isn't packaged). Defaults to `PlantSEED_Biomass_Template.json`
  so end-to-end runs produce a growth-testable model.

## Test suite

**54 tests, all passing.** Run from `Scripts/PlantSEED_v3/Annotation`:

```
pytest tests/
```

## Real-data validation

Runs against `/scratch1/seaver/OrthoFinder_Reference/OrthoFinder/Results_May26`
on 3 genomes:

| Genome | Phylum | Annotated features | Pair tags kept | Runtime |
|---|---|---:|---|---:|
| Sorghum bicolor v3.1.1 | Monocot | 1489 | O=4247 · PAM=361 · PAH=26 | 22 s cold |
| Populus trichocarpa v4.1 | Eudicot | 1766 | O=3632 · PAM=452 · PAH=32 | 2 s warm |
| Arabidopsis thaliana TAIR10 | Eudicot | 1480 | (self-annotation) | 0.3 s |

Compared against two hand-vetted plastidial reconstructions
(`BioFlux-Review/.../models_media/{sbicolor,ptrich}_..._ComplexFix_RevFix3_*.json`):

- **75-83 %** of shared reactions have identical GPRs.
- **21-27** reactions gain features via paralog admission
  (Rubisco small subunit family, Adenylate kinase, KASI, Pyruvate
  dehydrogenase, Acetolactate synthase, etc.).
- **Zero disjoint** feature sets on Sorghum, one on Populus.

Full GPR comparison at
`plantseed-v3/preprint_reconstructions_260806/qpsi_comparison_260806.md`
(not in this PR — output artefacts) — including the 40-reaction gap
against the current preprint model, traced to a different (likely
ProbModelSEED-derived) source annotation whose Sorghum candidates
aren't in the same OrthoFinder OGs as the curated Athaliana genes.

## Follow-up phases in the plan (not in this PR)

- Phase 1d — SHOOT-enriched reference build (`build_shoot_db.py`,
  `enrich_with_curated_proteins.py`). Would let non-Arabidopsis
  curated proteins in `PlantSEED_Roles.json` join the OrthoFinder
  families, closing part of the QPSI 40-reaction gap where the missing
  Sorghum candidates aren't reachable via Athaliana orthology.
- Phase 3 — Poplar celery worker packaging.
- Phase 4 — KBase SDK App wrapper (`kb_orthofinder` becomes a thin
  shim that pip-installs this package).
- Phase 5 — `plant_fba` runtime-refdata + stable-ID migration.

Companion `dy`-compartment PRs land the same defensive fix on the
KBase Python + Perl side:
- `kbaseapps/kb_orthofinder` PR `add-dy-compartment-260806`
- `kbaseapps/plant_fba` PR `add-dy-compartment-260806`
- `ModelSEED/PlantSEED` PR `add-dy-compartment-260806` (Perl scripts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
