### PR TITLE
Merge tied ortholog hits by role set instead of AMB_HIT rejection

### DIFF
--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/algorithms/propagate.py
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/algorithms/propagate.py
@@ -114,7 +114,15 @@ def build_curated_features(roles_data=None, include_uncurated=False):
 def _compose_function_string(sorted_roles, sorted_compartments):
     """`role1 / role2 # cpt-name1 # cpt-name2` — matches
     fetch_plantseed_impl.fetch_features's output. Unknown compartment
-    keys are dropped silently after a stderr warning."""
+    keys are dropped silently after a stderr warning.
+
+    Compartment NAMES are de-duped in append order because COMPARTMENT_MAPPING
+    is many-to-one (`d` and `cd` both map to `plastid`, `m`/`cm` to
+    `mitochondria`, `x`/`cx` to `peroxisome`, …). Direct callers pass in
+    keys from a single feature and won't ever hit a duplicate today, but
+    merge_functions() unions compartment lists across tied ortholog hits,
+    where duplicates ARE reachable.
+    """
     import sys
     role_str = " / ".join(sorted_roles)
     if not sorted_compartments:
@@ -124,10 +132,49 @@ def _compose_function_string(sorted_roles, sorted_compartments):
         if cpt not in COMPARTMENT_MAPPING:
             print(f"WARNING: no compartment mapping for {cpt!r}", file=sys.stderr)
             continue
-        mapped.append(COMPARTMENT_MAPPING[cpt])
+        name = COMPARTMENT_MAPPING[cpt]
+        if name not in mapped:
+            mapped.append(name)
     if not mapped:
         return role_str
     return role_str + " # " + " # ".join(mapped)
+
+
+def merge_functions(feature_entries):
+    """Merge curated-feature entries whose genes tied at the same PSI.
+
+    Returns `(function_string, roles, compartments)` when the entries
+    describe the same enzyme, or None when their role sets genuinely
+    conflict.
+
+    Two rules, both conservative:
+      * identical role sets  -> merge, roles unchanged
+      * nested role sets     -> merge on the INTERSECTION of the roles, so a
+                                tie can never introduce a role (and therefore
+                                a reaction) that only one candidate carried
+
+    Compartments are always the UNION across the merged entries: a gene that
+    is an equally good ortholog of a plastidial and a cytosolic copy of the
+    same enzyme is evidence for both localisations, not for neither.
+
+    Replaces the composed-string tie-break in psi_refined.annotate_query_gene
+    that was porting kb_orthofinderImpl.propagate_annotation's substring
+    comparison. See FIX_AMBHIT_ROLE_UNION_260812.md.
+    """
+    role_sets = [frozenset(e.get("roles") or ()) for e in feature_entries]
+    if not role_sets or not all(role_sets):
+        return None
+
+    shared = frozenset.intersection(*role_sets)
+    if len(set(role_sets)) != 1:
+        # Nested case only: some entry must contribute exactly the shared roles.
+        if not shared or not any(rs == shared for rs in role_sets):
+            return None
+
+    roles = sorted(shared)
+    compartments = sorted({c for e in feature_entries
+                           for c in (e.get("compartments") or ())})
+    return _compose_function_string(roles, compartments), roles, compartments
 
 
 def function_for_ortholog(top_ortholog, curated_features):

--- a/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/algorithms/psi_refined.py
+++ b/Scripts/PlantSEED_v3/Annotation/plantseed_annotation/algorithms/psi_refined.py
@@ -39,6 +39,7 @@ The tie-break rules are lifted verbatim from
 from collections import Counter, defaultdict
 
 from . import orthofinder_io as _oio
+from . import propagate as _propagate
 
 
 UNANNOTATED_LT_THRESHOLD = "Unannotated 1: LESS_THAN_THRESHOLD"
@@ -180,38 +181,35 @@ def annotate_query_gene(query_gene, ref_orthologs, psi_lookup_fn, threshold,
 
     top_refs = [ref for ref, p in psi_by_ref.items() if p == top_psi]
 
-    # Same three-rule tie-break as kb_orthofinderImpl.propagate_annotation:
-    functions = {}
-    for ref in top_refs:
-        fn = curated_features_for_ref.get(ref, {}).get("function") or "Unannotated"
-        functions.setdefault(fn, []).append(ref)
-
-    if len(functions) == 1:
-        top_ref = top_refs[0]
-    elif len(functions) == 2 and "Unannotated" in functions:
-        annotated_fn = [fn for fn in functions if fn != "Unannotated"][0]
-        top_ref = functions[annotated_fn][0]
-    elif len(functions) == 2:
-        fns_sorted = sorted(functions.keys())
-        if fns_sorted[0] in fns_sorted[1] or fns_sorted[1] in fns_sorted[0]:
-            top_ref = top_refs[0]
-        else:
-            return {"top_ortholog": None, "function": None, "psi": top_psi,
-                    "status": "AMB_HIT"}
-    else:
-        return {"top_ortholog": None, "function": None, "psi": top_psi,
-                "status": "AMB_HIT"}
-
-    fn = curated_features_for_ref.get(top_ref, {}).get("function")
-    if not fn:
+    # Tie-break. Replaces the composed-string comparison ported from
+    # kb_orthofinderImpl.propagate_annotation, which rejected same-enzyme hits
+    # that differed only in compartment. See FIX_AMBHIT_ROLE_UNION_260812.md.
+    curated_top = [r for r in top_refs
+                   if curated_features_for_ref.get(r, {}).get("function")]
+    if not curated_top:
         return {"top_ortholog": None, "function": None, "psi": top_psi,
                 "status": "NO_ORTHOLOG"}
+
+    if len(curated_top) == 1:
+        top_ref = curated_top[0]
+        fn = curated_features_for_ref[top_ref]["function"]
+        merged_from = None
+    else:
+        entries = [curated_features_for_ref[r] for r in curated_top]
+        merged = _propagate.merge_functions(entries)
+        if merged is None:
+            return {"top_ortholog": None, "function": None, "psi": top_psi,
+                    "status": "AMB_HIT"}
+        top_ref = sorted(curated_top)[0]
+        fn = merged[0]
+        merged_from = sorted(curated_top)
 
     return {
         "top_ortholog": (ref_species, top_ref),
         "function":     fn,
         "psi":          top_psi,
         "status":       "ANNOTATED",
+        "merged_from":  merged_from,
     }
 
 
@@ -353,5 +351,9 @@ def annotate_species(query_species, ref_species, orthologues_dict,
         )
         annotations[q_gene] = result
         stats[result["status"]] += 1
+        # Sub-count of ANNOTATED: how many ANNOTATED calls came from
+        # merging tied same-enzyme hits (FIX_AMBHIT_ROLE_UNION_260812).
+        if result.get("merged_from"):
+            stats["MERGED_COMPARTMENTS"] += 1
 
     return annotations, stats, pair_stats

--- a/Scripts/PlantSEED_v3/Annotation/tests/test_propagate.py
+++ b/Scripts/PlantSEED_v3/Annotation/tests/test_propagate.py
@@ -145,3 +145,126 @@ def test_function_for_ortholog_hit_and_miss():
         ("Athaliana_TAIR10", "AT1"), curated) == "Alpha # cytosol"
     assert propagate.function_for_ortholog(
         ("Athaliana_TAIR10", "MISSING"), curated) is None
+
+
+# --- merge_functions (FIX_AMBHIT_ROLE_UNION_260812) --------------------------
+def _e(roles, cpts):
+    """Compact factory for a curated-feature-entry shape merge_functions expects."""
+    return {"roles": list(roles), "compartments": list(cpts)}
+
+
+def test_merge_functions_identical_role_sets_union_compartments():
+    """Two entries with identical role sets merge cleanly. Compartments are
+    the union so a cytosolic and a plastidial copy of the same enzyme
+    together document both localisations."""
+    merged = propagate.merge_functions([
+        _e(["Alpha (EC 1.1.1.1)"], ["c"]),
+        _e(["Alpha (EC 1.1.1.1)"], ["d"]),
+    ])
+    assert merged is not None
+    fn, roles, cpts = merged
+    assert roles == ["Alpha (EC 1.1.1.1)"]
+    assert cpts == ["c", "d"]                # sorted union
+    assert fn == "Alpha (EC 1.1.1.1) # cytosol # plastid"
+
+
+def test_merge_functions_identical_role_sets_and_compartments_are_idempotent():
+    """Two identical entries collapse to that entry (compartments un-duplicated)."""
+    e = _e(["R1"], ["c"])
+    merged = propagate.merge_functions([e, e])
+    assert merged is not None
+    fn, roles, cpts = merged
+    assert roles == ["R1"]
+    assert cpts == ["c"]
+    assert fn == "R1 # cytosol"
+
+
+def test_merge_functions_nested_role_sets_merges_on_intersection():
+    """Nested case: one entry's roles are exactly the shared roles. Merge
+    keeps only the intersection so the tie can't introduce a role (and
+    therefore a reaction) that only one candidate carried."""
+    merged = propagate.merge_functions([
+        _e(["BCAA aminotransferase"], ["d"]),
+        _e(["BCAA aminotransferase", "MAM (EC 2.6.1.-)"], ["d"]),
+    ])
+    assert merged is not None
+    fn, roles, cpts = merged
+    assert roles == ["BCAA aminotransferase"]   # intersection only
+    assert "MAM" not in fn
+
+
+def test_merge_functions_conflicting_role_sets_returns_none():
+    """Two entries with disjoint role sets have no meaningful shared enzyme;
+    the caller must fall back to AMB_HIT."""
+    merged = propagate.merge_functions([
+        _e(["Alpha (EC 1.1.1.1)"], ["c"]),
+        _e(["Beta (EC 2.2.2.2)"],  ["d"]),
+    ])
+    assert merged is None
+
+
+def test_merge_functions_overlapping_but_neither_nested_returns_none():
+    """Neither {A, B} is a superset of the other (they overlap on A);
+    intersection isn't equal to any entry's role set, so bail out."""
+    merged = propagate.merge_functions([
+        _e(["A", "B"], ["c"]),
+        _e(["A", "C"], ["c"]),
+    ])
+    assert merged is None
+
+
+def test_merge_functions_empty_role_set_returns_none():
+    """Entry with no roles (rare — usually uncurated) can't participate."""
+    merged = propagate.merge_functions([
+        _e([], ["c"]),
+        _e(["R1"], ["c"]),
+    ])
+    assert merged is None
+    merged = propagate.merge_functions([])
+    assert merged is None
+
+
+def test_merge_functions_three_way_identical_role_sets():
+    """Three entries all with the same role set — merges, compartments unioned."""
+    merged = propagate.merge_functions([
+        _e(["Alpha (EC 1.1.1.1)"], ["c"]),
+        _e(["Alpha (EC 1.1.1.1)"], ["d"]),
+        _e(["Alpha (EC 1.1.1.1)"], ["m"]),
+    ])
+    assert merged is not None
+    fn, roles, cpts = merged
+    assert roles == ["Alpha (EC 1.1.1.1)"]
+    assert cpts == ["c", "d", "m"]
+
+
+def test_merge_functions_three_way_nested_requires_intersection_to_be_a_role_set():
+    """Rule 2 admits nested only when one entry IS the intersection.
+    {A} + {A, B} + {A, C}: intersection = {A}, but no entry equals {A}."""
+    merged = propagate.merge_functions([
+        _e(["A", "B"], ["c"]),
+        _e(["A", "C"], ["c"]),
+    ])
+    assert merged is None
+
+    # Add a plain {A} entry — now the intersection {A} matches an entry.
+    merged = propagate.merge_functions([
+        _e(["A", "B"], ["c"]),
+        _e(["A", "C"], ["c"]),
+        _e(["A"],      ["c"]),
+    ])
+    assert merged is not None
+    fn, roles, _ = merged
+    assert roles == ["A"]
+
+
+# --- compartment-name dedupe in _compose_function_string ---------------------
+def test_compose_function_string_dedupes_compartment_names():
+    """COMPARTMENT_MAPPING is many-to-one — e.g. `d` and `cd` both -> `plastid`.
+    _compose_function_string dedupes so a merge_functions union doesn't
+    produce `# plastid # plastid`."""
+    # `d` and `cd` both map to `plastid`; result should contain plastid once.
+    out = propagate._compose_function_string(["R1"], ["cd", "d"])
+    assert out == "R1 # plastid"
+    # `m` and `cm` both map to `mitochondria`; `c` maps to `cytosol`.
+    out = propagate._compose_function_string(["R1"], ["c", "cm", "m"])
+    assert out == "R1 # cytosol # mitochondria"

--- a/Scripts/PlantSEED_v3/Annotation/tests/test_psi_refined.py
+++ b/Scripts/PlantSEED_v3/Annotation/tests/test_psi_refined.py
@@ -7,11 +7,24 @@ from plantseed_annotation.algorithms import psi_refined as pr
 
 
 CURATED = {
-    "AT1": {"function": "Alpha (EC 1.1.1.1) # cytosol"},
-    "AT2": {"function": "Beta (EC 2.2.2.2) # plastid"},
-    "AT3": {"function": "Alpha (EC 1.1.1.1) # cytosol"},   # same fn as AT1
-    "AT4": {"function": "Alpha (EC 1.1.1.1) # cytosol # plastid"},  # substring-superset of AT1
-    "AT_UNANN": {"function": "Unannotated"},
+    "AT1": {"function":     "Alpha (EC 1.1.1.1) # cytosol",
+            "roles":        ["Alpha (EC 1.1.1.1)"],
+            "compartments": ["c"]},
+    "AT2": {"function":     "Beta (EC 2.2.2.2) # plastid",
+            "roles":        ["Beta (EC 2.2.2.2)"],
+            "compartments": ["d"]},
+    # AT3: same role/compartment as AT1 (identical role sets → merge cleanly)
+    "AT3": {"function":     "Alpha (EC 1.1.1.1) # cytosol",
+            "roles":        ["Alpha (EC 1.1.1.1)"],
+            "compartments": ["c"]},
+    # AT4: same role as AT1 but extra compartment (identical role sets →
+    # merge with unioned compartments per FIX_AMBHIT_ROLE_UNION_260812)
+    "AT4": {"function":     "Alpha (EC 1.1.1.1) # cytosol # plastid",
+            "roles":        ["Alpha (EC 1.1.1.1)"],
+            "compartments": ["c", "d"]},
+    # AT_UNANN represents a ref gene that isn't in the curated set —
+    # function is empty, so annotate_query_gene's curated_top filter drops it.
+    "AT_UNANN": {"function": ""},
 }
 
 
@@ -53,17 +66,23 @@ def test_annotate_unique_top_ref():
 
 
 def test_tie_break_same_function_arbitrary_pick():
-    """Two refs tied at top PSI with the same function → pick either
-    (deterministically the alphabetical first, per the port)."""
+    """Two refs tied at top PSI with the same role set → merge cleanly.
+    top_ortholog names the alphabetically-first of the merged set;
+    merged_from lists both."""
     r = pr.annotate_query_gene(
         "Q1", ["AT1", "AT3"], _psi_of({"AT1": 0.80, "AT3": 0.80}),
         threshold=0.60, curated_features_for_ref=CURATED, ref_species="Athaliana_TAIR10",
     )
     assert r["status"] == "ANNOTATED"
     assert r["function"] == "Alpha (EC 1.1.1.1) # cytosol"
+    assert r["top_ortholog"] == ("Athaliana_TAIR10", "AT1")
+    assert r["merged_from"] == ["AT1", "AT3"]
 
 
 def test_tie_break_unannotated_vs_annotated_picks_annotated():
+    """AT_UNANN represents an uncurated ref (function=''), which
+    curated_top filters out before merge. Only AT1 remains → ANNOTATED.
+    No merge, so merged_from is None."""
     r = pr.annotate_query_gene(
         "Q1", ["AT_UNANN", "AT1"], _psi_of({"AT_UNANN": 0.80, "AT1": 0.80}),
         threshold=0.60, curated_features_for_ref=CURATED, ref_species="Athaliana_TAIR10",
@@ -71,16 +90,21 @@ def test_tie_break_unannotated_vs_annotated_picks_annotated():
     assert r["status"] == "ANNOTATED"
     assert r["top_ortholog"] == ("Athaliana_TAIR10", "AT1")
     assert r["function"] == "Alpha (EC 1.1.1.1) # cytosol"
+    assert r["merged_from"] is None
 
 
-def test_tie_break_substring_variant_picks_either():
-    """AT1's function is a substring of AT4's (compartmentalization variant);
-    the ported rule picks one arbitrarily rather than ambiguating."""
+def test_tie_break_same_role_different_compartments_merges_with_union():
+    """AT1 (roles=[Alpha], compartments=[c]) and AT4 (roles=[Alpha],
+    compartments=[c, d]) have identical role sets but differ on compartments.
+    Under FIX_AMBHIT_ROLE_UNION_260812 they merge; compartments are the
+    union so the propagated function keeps both."""
     r = pr.annotate_query_gene(
         "Q1", ["AT1", "AT4"], _psi_of({"AT1": 0.80, "AT4": 0.80}),
         threshold=0.60, curated_features_for_ref=CURATED, ref_species="Athaliana_TAIR10",
     )
     assert r["status"] == "ANNOTATED"
+    assert r["function"] == "Alpha (EC 1.1.1.1) # cytosol # plastid"
+    assert r["merged_from"] == ["AT1", "AT4"]
 
 
 def test_tie_break_two_distinct_functions_ambiguous():
@@ -95,9 +119,12 @@ def test_tie_break_two_distinct_functions_ambiguous():
 
 
 def test_tie_break_three_distinct_functions_ambiguous():
-    """More than two distinct functions → always ambiguous."""
+    """More than two distinct role sets that are neither identical nor
+    nested → still AMB_HIT after the merge-based tie-break."""
     curated = dict(CURATED)
-    curated["AT5"] = {"function": "Gamma"}
+    curated["AT5"] = {"function":     "Gamma (EC 3.3.3.3)",
+                      "roles":        ["Gamma (EC 3.3.3.3)"],
+                      "compartments": ["c"]}
     r = pr.annotate_query_gene(
         "Q1", ["AT1", "AT2", "AT5"],
         _psi_of({"AT1": 0.80, "AT2": 0.80, "AT5": 0.80}),


### PR DESCRIPTION
Fixes defect B from FIX_AMBHIT_ROLE_UNION_260812.md (defects A and C explicitly deferred to the curation plan).

The old tie-break in psi_refined.annotate_query_gene ported kb_orthofinderImpl.propagate_annotation's composed-string comparison: when two curated Ath refs tied at top_psi, it accepted the pair only if one entry's composed function string was a literal substring of the other. That test operated on the wrong shape — the composed string has compartments appended in sorted order — so pairs like

  AT1G56190  Phosphoglycerate kinase (EC 2.7.2.3) # plastid
  AT3G12780  Phosphoglycerate kinase (EC 2.7.2.3) # cytosol # plastid

were rejected even though they are the same enzyme with overlapping localisations. Sorghum lost its plastidial PGK this way. S-adenosyl- methionine synthetase (Potri.014G114700, Potri.002G189200 at PSI 0.94-0.95) was rejected because two Ath copies are annotated `# cytosol` and `# nucleus`.

Fix: compare role SETS, not composed strings.

  - propagate.merge_functions(entries) — new helper. Identical role sets -> merge, roles unchanged. Nested (one entry's role set is exactly the intersection of all entries') -> merge on the intersection, so a tie can never introduce a role (and therefore a reaction) that only one candidate carried. Anything else -> None, caller falls back to AMB_HIT. Compartments are always the UNION: a gene equally close to a plastidial and a cytosolic copy of the same enzyme is evidence for both, not for neither.

  - propagate._compose_function_string now de-dupes compartment NAMES in append order. COMPARTMENT_MAPPING is many-to-one (d, cd both -> plastid; m, cm -> mitochondria; x, cx -> peroxisome), so a union across tied entries can produce `# plastid # plastid`. No current case triggers it, but the union makes it reachable.

  - psi_refined.annotate_query_gene's ~33-line tie-break block is replaced with a ~15-line role-set-driven version. Same public shape; adds an optional merged_from field naming the tied refs when a merge fired. The old behaviour of preferring an annotated hit over an "Unannotated" one is preserved by filtering uncurated refs from curated_top up-front.

  - psi_refined.annotate_species tracks MERGED_COMPARTMENTS as a sub-count of ANNOTATED for observability. Not a status; sits alongside status_counts in provenance.json.

Verified against annotator_fix_260812/replay_ambhit.py:

  Sorghum (Sbicolor_v3.1.1):
    ANNOTATED   1489 -> 1497   (+8)
    AMB_HIT       18 ->   10   (-8)
    NO_ORTHOLOG  127 unchanged
    MERGED_COMPARTMENTS = 169

  Poplar (Ptrichocarpa_v4.1):
    ANNOTATED   1766 -> 1772   (+6)
    AMB_HIT       15 ->    9   (-6)
    NO_ORTHOLOG  221 unchanged
    MERGED_COMPARTMENTS = 124

  Athaliana self-annotation unchanged.

Spot-checked three of the 14 recovered genes end-to-end against the FIX doc's §6 table:

  Sobic.001G447500 (BCAA aminotransferase, single nested-role case) —
    intersection kept only the shared BCAA role; the extra
    "2-oxo-5-methylthiopentanoate transaminase" role from AT3G49680
    correctly did NOT propagate.
  Sobic.009G183700 (PGK) — recovered with unioned cytosol + plastid.
  Sobic.001G260800 (Alanine transaminase) — recovered with tri-
    compartment cytosol + plastid + mitochondria.

Downstream, rxn01100_d0 (plastidial phosphoglycerate kinase) regains Sobic.009G183700 in the Sorghum model. The 19 real specificity conflicts (aliphatic vs aromatic desulfoglucosinolate sulfotransferase, tryptophan vs phenylalanine N-monooxygenase, 1,8-cineole vs ocimene synthase, ...) continue to reject as AMB_HIT.

Tests: +9 (63 total, was 54). Six new tests cover merge_functions' rules (identical, nested, disjoint, overlapping-but-not-nested, empty, three-way); two update the tie-break tests in test_psi_refined to pin the new merge-with-union behaviour; one covers compartment-name de-dupe in _compose_function_string.

Not fixed by this change (deferred per the FIX doc's §8):
  - Defect A — winner-take-all discards compartments (NADP-ME).
  - Defect C — an uncurated gene sets the OG baseline (APS kinase).
  - Orthogroups with no reference-species member.
  - Curation typos in PlantSEED_Roles.json.

Not regenerating the reconstructions in
PlantSEED/Papers/bioflux-preprint-260807/ — the BioFlux manuscript figures are frozen against the current models; coordinate before replacing them.